### PR TITLE
fix : 카카오 유저 정보 가져오기 기능을 수정한다.

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/auth/controller/AuthController.java
+++ b/src/main/java/efub/back/jupjup/domain/auth/controller/AuthController.java
@@ -1,4 +1,4 @@
-package efub.back.jupjup.domain.auth;
+package efub.back.jupjup.domain.auth.controller;
 
 import efub.back.jupjup.domain.auth.dto.DemoResDto;
 import efub.back.jupjup.domain.security.exception.EmptyTokenException;

--- a/src/main/java/efub/back/jupjup/domain/member/domain/AgeRange.java
+++ b/src/main/java/efub/back/jupjup/domain/member/domain/AgeRange.java
@@ -3,22 +3,39 @@ package efub.back.jupjup.domain.member.domain;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 @Getter
 @AllArgsConstructor
 public enum AgeRange {
-    AGE_0_9("0", "0~9세"),
-    AGE_10_14("1", "10~14세"),
-    AGE_15_19("2", "15~19세"),
-    AGE_20_29("3", "20~29세"),
-    AGE_30_39("4", "30~39세"),
-    AGE_40_49("5", "40~49세"),
-    AGE_50_59("6", "50~59세"),
-    AGE_60_69("7", "60~69세"),
-    AGE_70_79("8", "70~79세"),
-    AGE_80_80("9", "80~89세"),
-    AGE_90_ABOVE("10", "90세~");
+    AGE_0_9("0", "0~9"),
+    AGE_10_14("1", "10~14"),
+    AGE_15_19("2", "15~19"),
+    AGE_10_19("3", "10~19"),
+    AGE_20_29("4", "20~29"),
+    AGE_30_39("5", "30~39"),
+    AGE_40_49("6", "40~49"),
+    AGE_50_59("7", "50~59"),
+    AGE_60_69("8", "60~69"),
+    AGE_70_79("9", "70~79"),
+    AGE_80_80("10", "80~89"),
+    AGE_90_ABOVE("11", "90~");
 
     private final String code;
     private final String description;
 
+    private static final Map<String, String> AGE_RANGE_MAP = Collections.unmodifiableMap(
+            Stream.of(values()).collect(Collectors.toMap(AgeRange::getDescription, AgeRange::name)));
+
+    public static AgeRange fromString(final String ageRangeStr){
+        AgeRange ageRange = AgeRange.valueOf(AGE_RANGE_MAP.get(ageRangeStr));
+        if(ageRange.equals(AgeRange.AGE_10_14) || ageRange.equals(AgeRange.AGE_15_19)){
+            ageRange = AgeRange.AGE_10_19;
+        }
+
+        return ageRange;
+    }
 }

--- a/src/main/java/efub/back/jupjup/domain/member/domain/Gender.java
+++ b/src/main/java/efub/back/jupjup/domain/member/domain/Gender.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum Gender {
     FEMALE("female"),
-    MALE("male");
+    MALE("male"),
+    NOT_DEFINED("not defined");
 
     private final String description;
 }

--- a/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
+++ b/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member extends BaseTimeEntity {
-    public static final String FORBIDDEN_WORD = "unknown";
+    public static final String INFO_UNKNOWN = "unknown";
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id", updatable = false)
@@ -67,7 +67,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean validateNickName(String nickname) {
-        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(FORBIDDEN_WORD)) {
+        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
             throw new InvalidNicknameException();
         }else{
             return true;
@@ -111,9 +111,9 @@ public class Member extends BaseTimeEntity {
         }
     }
     public void withdrawInfoProcess(){
-        this.nickname = FORBIDDEN_WORD;
-        this.email = FORBIDDEN_WORD;
-        this.username = FORBIDDEN_WORD;
+        this.nickname = INFO_UNKNOWN;
+        this.email = INFO_UNKNOWN;
+        this.username = INFO_UNKNOWN;
         this.providerType = null;
         this.profileImageUrl = null;
         this.memberStatus = MemberStatus.WITHDRAWN;

--- a/src/main/java/efub/back/jupjup/domain/post/domain/Post.java
+++ b/src/main/java/efub/back/jupjup/domain/post/domain/Post.java
@@ -1,5 +1,6 @@
 package efub.back.jupjup.domain.post.domain;
 
+import efub.back.jupjup.domain.member.domain.AgeRange;
 import efub.back.jupjup.global.BaseTimeEntity;
 import java.time.LocalDateTime;
 import javax.persistence.*;

--- a/src/main/java/efub/back/jupjup/domain/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/efub/back/jupjup/domain/security/service/CustomOAuth2UserService.java
@@ -1,8 +1,6 @@
 package efub.back.jupjup.domain.security.service;
 
-import efub.back.jupjup.domain.member.domain.Member;
-import efub.back.jupjup.domain.member.domain.MemberStatus;
-import efub.back.jupjup.domain.member.domain.RoleType;
+import efub.back.jupjup.domain.member.domain.*;
 import efub.back.jupjup.domain.member.repository.MemberRepository;
 import efub.back.jupjup.domain.security.userInfo.KakaoUserInfo;
 import efub.back.jupjup.domain.security.userInfo.PrincipalDetails;
@@ -19,7 +17,7 @@ import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
 
 import java.util.Objects;
 
-import static efub.back.jupjup.domain.member.domain.Member.FORBIDDEN_WORD;
+import static efub.back.jupjup.domain.member.domain.Member.INFO_UNKNOWN;
 
 
 @Slf4j
@@ -55,6 +53,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 .orElseGet(() -> {
                     if (!memberRepository.existsByEmail(oAuth2UserInfo.getEmail())) {
                         String nickname = oAuth2UserInfo.getNickname();
+                        log.info("카카오 닉네임 : " + nickname);
                         if(invalidateNickname(nickname)){
                             nickname = String.valueOf(System.currentTimeMillis());
                         }
@@ -64,6 +63,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 .profileImageUrl(oAuth2UserInfo.getProfileImageUrl())
                                 .username(oAuth2UserInfo.getName())
                                 .providerType(oAuth2UserInfo.getProvider())
+                                .ageRange(AgeRange.fromString(oAuth2UserInfo.getAgeRange()))
+                                .gender(oAuth2UserInfo.getGender() == null ? Gender.NOT_DEFINED : Gender.valueOf(oAuth2UserInfo.getGender().toUpperCase().trim()))
                                 .roleType(RoleType.MEMBER)
                                 .status(MemberStatus.ACTIVE)
                                 .build();
@@ -82,7 +83,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     public boolean invalidateNickname(String nickname) {
-        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(FORBIDDEN_WORD)) {
+        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
             return true;
         }
 


### PR DESCRIPTION
## 기능 명세
- [x] gender와 ageRange가 제대로 들어가지 않는 문제 해결
- [x] 카카오가 gender가 설정되지 않은 경우(카카오에서 필수 설정이 아님) GENDER.NOT_DEFINED로 저장
- [x] 카카오에서 10~14, 15~19로 age_range가 나뉘어오는데, 두 경우 모두 서버에서는 10~19로 변환해서 저장

## 결과 
별도의 API 없음

## 함께 의논할 점
- post 도메인에서는 AgeRange와 Gender enum이 있는 것 같은데, member에서도 동일하게 사용해서 이름을 바꾸면 좋을 것 같습니다
- post 도메인에서 사용하는 AgeRange는 범위로 설정해서 여러개가 들어가는 경우도 있을 것 같은데 현재 방식으로는 문제가 되지 않을까요..?
## Resolve
#1
