### PR TITLE
feat : 멤버 관련 기능을 구현한다.

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
@@ -1,0 +1,41 @@
+package efub.back.jupjup.domain.member.controller;
+
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
+import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
+import efub.back.jupjup.domain.member.service.MemberService;
+import efub.back.jupjup.domain.security.userInfo.AuthUser;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<StatusResponse> readProfile(@PathVariable Long memberId){
+        return memberService.readProfile(memberId);
+    }
+
+    @PutMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<StatusResponse> updateProfile(@AuthUser Member member, @RequestBody MemberReqDto memberReqDto){
+        return memberService.updateProfile(member, memberReqDto);
+    }
+
+    @PostMapping("/checkNickname")
+    public ResponseEntity<StatusResponse> checkDuplicateNickname(@RequestBody NicknameCheckReqDto nicknameCheckReqDto){
+        return memberService.checkDuplicateNickname(nicknameCheckReqDto);
+    }
+}

--- a/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
+++ b/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
@@ -67,7 +67,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean validateNickName(String nickname) {
-        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
+        if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches("[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
             throw new InvalidNicknameException();
         }else{
             return true;

--- a/src/main/java/efub/back/jupjup/domain/member/dto/request/MemberReqDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/request/MemberReqDto.java
@@ -1,0 +1,15 @@
+package efub.back.jupjup.domain.member.dto.request;
+
+import efub.back.jupjup.domain.member.domain.AgeRange;
+import efub.back.jupjup.domain.member.domain.Gender;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberReqDto {
+    private String nickname;
+    private String gender;
+    private String profileImage;
+}

--- a/src/main/java/efub/back/jupjup/domain/member/dto/request/NicknameCheckReqDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/request/NicknameCheckReqDto.java
@@ -1,0 +1,11 @@
+package efub.back.jupjup.domain.member.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameCheckReqDto {
+    private String nickname;
+}

--- a/src/main/java/efub/back/jupjup/domain/member/dto/response/MemberResDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/response/MemberResDto.java
@@ -1,0 +1,32 @@
+package efub.back.jupjup.domain.member.dto.response;
+
+import efub.back.jupjup.domain.member.domain.AgeRange;
+import efub.back.jupjup.domain.member.domain.Gender;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.security.userInfo.ProviderType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberResDto {
+    private Long id;
+    private String email;
+    private String profileImageUrl;
+    private String nickname;
+    private ProviderType providerType;
+    private AgeRange ageRange;
+    private Gender gender;
+
+    public static MemberResDto from(Member member){
+        return MemberResDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .providerType(member.getProviderType())
+                .ageRange(member.getAgeRange())
+                .gender(member.getGender())
+                .build();
+    }
+}

--- a/src/main/java/efub/back/jupjup/domain/member/dto/response/NicknameCheckResDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/response/NicknameCheckResDto.java
@@ -1,0 +1,12 @@
+package efub.back.jupjup.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NicknameCheckResDto {
+    private Boolean isExistingNickname;
+}

--- a/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
+++ b/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
@@ -1,0 +1,56 @@
+package efub.back.jupjup.domain.member.service;
+
+import efub.back.jupjup.domain.member.domain.Gender;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
+import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
+import efub.back.jupjup.domain.member.dto.response.MemberResDto;
+import efub.back.jupjup.domain.member.dto.response.NicknameCheckResDto;
+import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
+import efub.back.jupjup.domain.member.repository.MemberRepository;
+import efub.back.jupjup.global.response.StatusEnum;
+import efub.back.jupjup.global.response.StatusResponse;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public ResponseEntity<StatusResponse> updateProfile(Member member, MemberReqDto memberReqDto) {
+        member.updateNickname(memberReqDto.getNickname());
+        member.updateGender(Gender.valueOf(memberReqDto.getGender()));
+        member.updateProfileImage(memberReqDto.getProfileImage());
+        Member updatedMember = memberRepository.save(member);
+        MemberResDto memberResDto = MemberResDto.from(updatedMember);
+        return make200Response(memberResDto);
+    }
+
+    public ResponseEntity<StatusResponse> readProfile(Long memberId){
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        MemberResDto memberResDto = MemberResDto.from(member);
+        return make200Response(memberResDto);
+    }
+
+    public ResponseEntity<StatusResponse> checkDuplicateNickname(NicknameCheckReqDto reqDto){
+        boolean isExistingNickname = memberRepository.existsByNickname(reqDto.getNickname());
+        NicknameCheckResDto resDto = new NicknameCheckResDto(isExistingNickname);
+        return make200Response(resDto);
+    }
+
+    private ResponseEntity<StatusResponse> make200Response(Object obj){
+        return ResponseEntity.ok()
+                .body(StatusResponse.builder()
+                        .status(StatusEnum.OK.getStatusCode())
+                        .message(StatusEnum.OK.getCode())
+                        .data(obj)
+                        .build());
+    }
+}


### PR DESCRIPTION
## 기능 명세
- [x] 프로필 조회
- [x] 프로필 생성 및 수정
- [x] 닉네임 중복 확인 기능
## 결과 
### [PUT] /api/v1/member
프로필 생성 및 수정
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 1,
        "email": "gy5027@naver.com",
        "profileImageUrl": "https://",
        "nickname": "가영2",
        "providerType": "KAKAO",
        "ageRange": "AGE_20_29",
        "gender": "FEMALE"
    }
}
```
### [GET] /api/v1/member/{memberId}
프로필 조회
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 1,
        "email": "gy5027@naver.com",
        "profileImageUrl": "https://",
        "nickname": "가영2",
        "providerType": "KAKAO",
        "ageRange": "AGE_20_29",
        "gender": "FEMALE"
    }
}
```

### [POST] /api/v1/member/checkNickname
닉네임 중복 확인
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "isExistingNickname": false
    }
}
```
## 함께 의논할 점
> 없으면 생략 
## Resolve
closes : #8
