### PR TITLE
feat : 사용자 신고 기능을 구현한다.

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/image/service/ImageService.java
+++ b/src/main/java/efub/back/jupjup/domain/image/service/ImageService.java
@@ -1,0 +1,83 @@
+package efub.back.jupjup.domain.image.service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import efub.back.jupjup.domain.image.S3Upload;
+import efub.back.jupjup.domain.post.domain.Post;
+import efub.back.jupjup.domain.post.domain.PostImage;
+import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
+import efub.back.jupjup.domain.post.exception.EmptyInputFilenameException;
+import efub.back.jupjup.domain.post.exception.WrongImageFormatException;
+import efub.back.jupjup.domain.post.repository.PostImageRepository;
+import efub.back.jupjup.domain.report.domain.Report;
+import efub.back.jupjup.domain.report.domain.ReportImage;
+import efub.back.jupjup.domain.report.repository.ReportImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ImageService {
+	private final S3Upload s3Upload;
+	private final PostImageRepository postImageRepository;
+	private final ReportImageRepository reportImageRepository;
+
+	public List<ImageUploadResponseDto> getPresignedUrls(List<String> fileNameList) {
+		return fileNameList.stream().map(raw -> {
+			isValidFileExtension(raw);
+			String fileName = createRandomFileName(raw);
+			String presignedUrl = s3Upload.getPresignedUrl(fileName);
+
+			return ImageUploadResponseDto.builder()
+				.rawFile(raw)
+				.fileName(fileName)
+				.presignedUrl(presignedUrl)
+				.build();
+		}).collect(Collectors.toList());
+	}
+
+	public List<String> saveImageUrlsPost(List<String> images, Post post) {
+		List<String> imageUrls = new ArrayList<>();
+		for (String fileUrl : images) {
+			PostImage postImage = postImageRepository.save(new PostImage(fileUrl, post));
+			imageUrls.add(postImage.getFileUrl());
+		}
+
+		return imageUrls;
+	}
+
+	public List<String> saveImageUrlsReport(List<String> images, Report report) {
+		List<String> imageUrls = new ArrayList<>();
+		for (String fileUrl : images) {
+			ReportImage reportImage = reportImageRepository.save(new ReportImage(fileUrl, report));
+			imageUrls.add(reportImage.getFileUrl());
+		}
+
+		return imageUrls;
+	}
+
+	public String createRandomFileName(String rawFile) {
+		return UUID.randomUUID() + rawFile;
+	}
+
+	private void isValidFileExtension(String fileName) {
+		if (fileName.length() == 0) {
+			throw new EmptyInputFilenameException();
+		}
+
+		String[] validExtensions = {".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"};
+		String idxFileName = fileName.substring(fileName.lastIndexOf("."));
+		if (!Arrays.asList(validExtensions).contains(idxFileName)) {
+			throw new WrongImageFormatException();
+		}
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -1,13 +1,8 @@
 package efub.back.jupjup.domain.post.service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
-
-import efub.back.jupjup.domain.image.S3Upload;
 import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.post.domain.Post;
 import efub.back.jupjup.domain.post.domain.PostAgeRange;
@@ -17,12 +12,10 @@ import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
 import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
 import efub.back.jupjup.domain.post.dto.PostRequestDto;
 import efub.back.jupjup.domain.post.dto.PostResponseDto;
-import efub.back.jupjup.domain.post.exception.EmptyInputFilenameException;
-import efub.back.jupjup.domain.post.exception.WrongImageFormatException;
 import efub.back.jupjup.domain.post.repository.PostImageRepository;
 import efub.back.jupjup.domain.post.repository.PostRepository;
 import efub.back.jupjup.domain.postjoin.repository.PostjoinRepository;
-import efub.back.jupjup.domain.postjoin.service.PostjoinService;
+import efub.back.jupjup.domain.image.service.ImageService;
 import efub.back.jupjup.global.response.StatusEnum;
 import efub.back.jupjup.global.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,10 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class PostService {
-	private final S3Upload s3Upload;
 	private final PostRepository postRepository;
 	private final PostImageRepository postImageRepository;
 	private final PostjoinRepository postjoinRepository;
+	private final ImageService imageService;
 
 	private StatusResponse createStatusResponse(Object data) {
 		return StatusResponse.builder()
@@ -55,7 +48,7 @@ public class PostService {
 		Post post = requestDto.toEntity(requestDto, member);
 		postRepository.save(post);
 
-		List<String> imageUrls = saveImageUrls(requestDto.getImages(), post);
+		List<String> imageUrls = imageService.saveImageUrlsPost(requestDto.getImages(), post);
 		boolean isJoined = false;
 		boolean isEnded = false;
 
@@ -176,49 +169,9 @@ public class PostService {
 
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getPresignedUrls(Member member, ImageUploadRequestDto imageUploadRequestDto) {
-		List<String> fileNameList = imageUploadRequestDto.getImageList();
-		log.info(String.valueOf(fileNameList.size()));
 
-		List<ImageUploadResponseDto> urls = fileNameList.stream().map(raw -> {
-			//이미지 파일이 유효한 확장자인지 검사
-			isValidFileExtension(raw);
-			String fileName = createRandomFileName(raw);
-			String presignedUrl = s3Upload.getPresignedUrl(fileName);
-
-			return ImageUploadResponseDto.builder()
-				.rawFile(raw)
-				.fileName(fileName)
-				.presignedUrl(presignedUrl)
-				.build();
-		}).collect(Collectors.toList());
-
+		List<ImageUploadResponseDto> urls = imageService.getPresignedUrls(imageUploadRequestDto.getImageList());
 		return ResponseEntity.ok(createStatusResponse(urls));
-	}
-
-	private List<String> saveImageUrls(List<String> images, Post post) {
-		List<String> imageUrls = new ArrayList<>();
-		for (String fileUrl : images) {
-			PostImage postImage = postImageRepository.save(new PostImage(fileUrl, post));
-			imageUrls.add(postImage.getFileUrl());
-		}
-
-		return imageUrls;
-	}
-
-	private String createRandomFileName(String rawFile) {
-		return UUID.randomUUID() + rawFile;
-	}
-
-	private void isValidFileExtension(String fileName) {
-		if (fileName.length() == 0) {
-			throw new EmptyInputFilenameException();
-		}
-
-		String[] validExtensions = {".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"};
-		String idxFileName = fileName.substring(fileName.lastIndexOf("."));
-		if (!Arrays.asList(validExtensions).contains(idxFileName)) {
-			throw new WrongImageFormatException();
-		}
 	}
 
 	private void checkValidMember(Long memberId, Long authorId) {

--- a/src/main/java/efub/back/jupjup/domain/report/controller/ReportController.java
+++ b/src/main/java/efub/back/jupjup/domain/report/controller/ReportController.java
@@ -1,0 +1,35 @@
+package efub.back.jupjup.domain.report.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
+import efub.back.jupjup.domain.report.dto.ReportRequestDto;
+import efub.back.jupjup.domain.report.service.ReportService;
+import efub.back.jupjup.domain.security.userInfo.AuthUser;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+public class ReportController {
+	private final ReportService reportService;
+	@PostMapping
+	public ResponseEntity<StatusResponse> submitReport(@RequestBody ReportRequestDto reportRequestDto,
+		@AuthUser Member member) {
+		return reportService.createReport(reportRequestDto, member);
+	}
+
+	@PostMapping("/images")
+	public ResponseEntity<StatusResponse> getPresignedUrls(@AuthUser Member member,
+		@RequestBody ImageUploadRequestDto imageUploadRequestDto) {
+		return reportService.getPresignedUrls(member, imageUploadRequestDto);
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/report/domain/Report.java
+++ b/src/main/java/efub/back/jupjup/domain/report/domain/Report.java
@@ -1,8 +1,11 @@
 package efub.back.jupjup.domain.report.domain;
 
+import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.global.BaseTimeEntity;
 
 import javax.persistence.*;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,17 +15,23 @@ import lombok.NoArgsConstructor;
 public class Report extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "id")
-	private Long reportId;
+	@Column(updatable = false)
+	private Long id;
 
-	@Column
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "writer_id", nullable = false)
+	private Member writer;
+
+	@Column(nullable = false)
+	private Long targetId;
+
+	@Column(length = 999)
 	private String content;
 
-	@Column(name = "member_id", nullable = false)
-	private Long memberId;
-
-	public Report(Long memberId, String content){
-		this.memberId = memberId;
+	@Builder
+	public Report(Member writer, Long targetId, String content){
+		this.writer = writer;
+		this.targetId = targetId;
 		this.content = content;
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/report/domain/ReportImage.java
+++ b/src/main/java/efub/back/jupjup/domain/report/domain/ReportImage.java
@@ -1,0 +1,34 @@
+package efub.back.jupjup.domain.report.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReportImage {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", updatable = false)
+	private Long id;
+
+	private String fileUrl;
+
+	@ManyToOne
+	@JoinColumn(name = "report_id")
+	private Report report;
+
+	public ReportImage(String fileUrl, Report report) {
+		this.fileUrl = fileUrl;
+		this.report = report;
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/efub/back/jupjup/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,25 @@
+package efub.back.jupjup.domain.report.dto;
+
+import java.util.List;
+
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.report.domain.Report;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportRequestDto {
+	private Long targetId;
+	private String content;
+	private List<String> images;
+
+	public Report toEntity(ReportRequestDto dto, Member writer) {
+		return Report.builder()
+			.targetId(dto.getTargetId())
+			.content(dto.getContent())
+			.writer(writer)
+			.build();
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/efub/back/jupjup/domain/report/dto/ReportResponseDto.java
@@ -1,0 +1,34 @@
+package efub.back.jupjup.domain.report.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import efub.back.jupjup.domain.report.domain.Report;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ReportResponseDto {
+	private  Long id;
+	private Long writerId;
+	private Long targetId;
+	private String content;
+	private List<String> fileUrls;
+	private LocalDateTime createdDate;
+
+	public static ReportResponseDto of(Report report, List<String> imgUrlList){
+		return ReportResponseDto.builder()
+			.id(report.getId())
+			.writerId(report.getWriter().getId())
+			.targetId(report.getTargetId())
+			.content(report.getContent())
+			.fileUrls(imgUrlList)
+			.createdDate(report.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/report/repository/ReportImageRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/report/repository/ReportImageRepository.java
@@ -1,0 +1,7 @@
+package efub.back.jupjup.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import efub.back.jupjup.domain.report.domain.ReportImage;
+
+public interface ReportImageRepository extends JpaRepository<ReportImage, String> {
+}

--- a/src/main/java/efub/back/jupjup/domain/report/repository/ReportRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/report/repository/ReportRepository.java
@@ -1,0 +1,10 @@
+package efub.back.jupjup.domain.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import efub.back.jupjup.domain.report.domain.Report;
+
+import java.util.Optional;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+	Optional<Report> findById(Long reportId);
+}

--- a/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
+++ b/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
@@ -1,0 +1,55 @@
+package efub.back.jupjup.domain.report.service;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import efub.back.jupjup.domain.image.service.ImageService;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
+import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
+import efub.back.jupjup.domain.report.domain.Report;
+import efub.back.jupjup.domain.report.dto.ReportRequestDto;
+import efub.back.jupjup.domain.report.dto.ReportResponseDto;
+import efub.back.jupjup.domain.report.repository.ReportRepository;
+import efub.back.jupjup.global.response.StatusEnum;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ReportService {
+	private final ReportRepository reportRepository;
+	private final ImageService imageService;
+
+	private StatusResponse createStatusResponse(Object data) {
+		return StatusResponse.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(StatusEnum.OK.getCode())
+			.data(data)
+			.build();
+	}
+
+	// 신고글 작성하기
+	public ResponseEntity<StatusResponse> createReport(ReportRequestDto reportRequestDto, Member member) {
+		Report report = reportRequestDto.toEntity(reportRequestDto, member);
+		reportRepository.save(report);
+
+		List<String> imageUrls = imageService.saveImageUrlsReport(reportRequestDto.getImages(), report);
+		ReportResponseDto reportResponseDto = ReportResponseDto.of(report,imageUrls);
+
+		return ResponseEntity.ok(createStatusResponse(reportResponseDto));
+	}
+
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getPresignedUrls(Member member, ImageUploadRequestDto imageUploadRequestDto) {
+
+		List<ImageUploadResponseDto> urls = imageService.getPresignedUrls(imageUploadRequestDto.getImageList());
+		return ResponseEntity.ok(createStatusResponse(urls));
+	}
+}


### PR DESCRIPTION
## 기능 명세
- [x] 사용자 신고 작성 기능
- [x] 사용자 신고 첨부 이미지 업로드
- [x] 이미지 Presigned Url 발급 메서드 분리 

## 결과 
🔻예시
### [POST] [/api/v1/reports]
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 1,
        "writerId": 1,
        "targetId": 2,
        "content": "신고사유 작성",
        "fileUrls": [
            "image1_url_here.jpg",
            "image2_url_here.png"
        ],
        "createdDate": "2023-11-06T02:20:33.8782341"
    }
}
```

## Resolve
#12 
