### PR TITLE
feat: 토큰 없이 게시글 리스트 보기 기능 구현한다.

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
+++ b/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
@@ -39,10 +39,22 @@ public class PostController {
 		return postService.getAllPosts(member);
 	}
 
+	// 전체 게시글 리스트 조회 - (로그인 없이)
+	@GetMapping("/list/unauth")
+	public ResponseEntity<StatusResponse> getPosts() {
+		return postService.getAllPostsUnAuth();
+	}
+
 	// 성별 필터링 게시글 리스트 조회
 	@GetMapping("/listByGender")
 	public ResponseEntity<StatusResponse> getPostsByGender(@RequestParam String postGender, @AuthUser Member member) {
 		return postService.getPostsByGender(postGender, member);
+	}
+
+	// 성별 필터링 게시글 리스트 조회 - 로그인 없이
+	@GetMapping("/listByGender/unauth")
+	public ResponseEntity<StatusResponse> getPostsByGender(@RequestParam String postGender) {
+		return postService.getPostsByGenderUnAuth(postGender);
 	}
 
 	// 나이대 필터링 게시글 리스트 조회
@@ -52,10 +64,23 @@ public class PostController {
 		return postService.getPostsByAgeRange(postAgeRange, member);
 	}
 
+	// 나이대 필터링 게시글 리스트 조회 - 로그인 없이
+	@GetMapping("/listByAgeRange/unauth")
+	public ResponseEntity<StatusResponse> getPostsByAgeRange(@RequestParam String postAgeRangeStr) {
+		PostAgeRange postAgeRange = PostAgeRange.fromString(postAgeRangeStr);
+		return postService.getPostsByAgeRangeUnAuth(postAgeRange);
+	}
+
 	// 반려동물 여부 필터링 게시글 리스트 조회
 	@GetMapping("/listByPet")
 	public ResponseEntity<StatusResponse> getPostsByWithPet(@RequestParam boolean withPet, @AuthUser Member member) {
 		return postService.getPostsByWithPet(withPet, member);
+	}
+
+	// 반려동물 여부 필터링 게시글 리스트 조회 - 로그인 없이
+	@GetMapping("/listByPet/unauth")
+	public ResponseEntity<StatusResponse> getPostsByWithPet(@RequestParam boolean withPet) {
+		return postService.getPostsByWithPetUnAuth(withPet);
 	}
 
 	// 게시글 삭제

--- a/src/main/java/efub/back/jupjup/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/efub/back/jupjup/domain/post/dto/PostResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Getter
 @Builder
@@ -27,13 +28,13 @@ public class PostResponseDto {
 	private List<String> fileUrls;
 	private Boolean withPet;
 	private Long authorId;
-	private Boolean isJoined; // 참여 여부를 표시하는 필드
+	private Optional<Boolean> isJoined; // 참여 여부를 표시하는 필드
 	private Boolean isEnded;  // 모집 마감 여부를 표시하는 필드
 	private String authorNickname;           // 글쓴이의 닉네임 필드
 	private String authorProfileImageUrl;    // 글쓴이의 프로필 이미지 URL 필드
 
 
-	public static PostResponseDto of(Post post, List<String> imgUrlList, Boolean isJoined, Boolean isEnded) {
+	public static PostResponseDto of(Post post, List<String> imgUrlList, Optional<Boolean> isJoined, Boolean isEnded) {
 
 		return PostResponseDto.builder()
 			.id(post.getId())

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -22,7 +23,6 @@ import efub.back.jupjup.domain.post.exception.WrongImageFormatException;
 import efub.back.jupjup.domain.post.repository.PostImageRepository;
 import efub.back.jupjup.domain.post.repository.PostRepository;
 import efub.back.jupjup.domain.postjoin.repository.PostjoinRepository;
-import efub.back.jupjup.domain.postjoin.service.PostjoinService;
 import efub.back.jupjup.global.response.StatusEnum;
 import efub.back.jupjup.global.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +59,7 @@ public class PostService {
 		boolean isJoined = false;
 		boolean isEnded = false;
 
-		PostResponseDto postResponseDto = PostResponseDto.of(post,imageUrls, isJoined, isEnded);
+		PostResponseDto postResponseDto = PostResponseDto.of(post,imageUrls, Optional.of(isJoined), isEnded);
 
 		return ResponseEntity.ok(createStatusResponse(postResponseDto));
 	}
@@ -77,7 +77,7 @@ public class PostService {
 		boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
 		boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-		PostResponseDto responseDto = PostResponseDto.of(post, urlList, isJoined, isEnded);
+		PostResponseDto responseDto = PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
 		return ResponseEntity.ok(createStatusResponse(responseDto));
 	}
 
@@ -95,7 +95,26 @@ public class PostService {
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, isJoined, isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+		}).collect(Collectors.toList());
+
+		return ResponseEntity.ok(createStatusResponse(responseDtos));
+	}
+
+	// 플로깅 게시글 리스트 보기 - (로그인 없이)
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getAllPostsUnAuth(){
+		List<Post> posts = postRepository.findAll();
+
+		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
+			List<String> urlList = postImageRepository.findAllByPost(post)
+				.stream()
+				.map(PostImage::getFileUrl)
+				.collect(Collectors.toList());
+
+			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
+
+			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -117,7 +136,28 @@ public class PostService {
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, isJoined, isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+		}).collect(Collectors.toList());
+
+		return ResponseEntity.ok(createStatusResponse(responseDtos));
+	}
+
+	// 성별을 기준으로 게시글 필터링 하는 기능 - (로그인 없이)
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getPostsByGenderUnAuth(String postGenderStr) {
+
+		PostGender postGender = PostGender.valueOf(postGenderStr.toUpperCase());
+		List<Post> posts = postRepository.findAllByPostGender(postGender);
+
+		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
+			List<String> urlList = postImageRepository.findAllByPost(post)
+				.stream()
+				.map(PostImage::getFileUrl)
+				.collect(Collectors.toList());
+
+			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
+
+			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -138,7 +178,27 @@ public class PostService {
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, isJoined, isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+		}).collect(Collectors.toList());
+
+		return ResponseEntity.ok(createStatusResponse(responseDtos));
+	}
+
+	// 나이를 기준으로 게시글 필터링 하는 기능 - (로그인 없이)
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getPostsByAgeRangeUnAuth(PostAgeRange postAge) {
+
+		List<Post> posts = postRepository.findAllByPostAgeRangesContaining(postAge);
+
+		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
+			List<String> urlList = postImageRepository.findAllByPost(post)
+				.stream()
+				.map(PostImage::getFileUrl)
+				.collect(Collectors.toList());
+
+			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
+
+			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -159,7 +219,27 @@ public class PostService {
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, isJoined, isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+		}).collect(Collectors.toList());
+
+		return ResponseEntity.ok(createStatusResponse(responseDtos));
+	}
+
+	// 반려동물 여부 기준으로 게시글 필터링 하는 기능 - (로그인 없이)
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getPostsByWithPetUnAuth(boolean withPetValue) {
+
+		List<Post> posts = postRepository.findAllByWithPet(withPetValue);
+
+		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
+			List<String> urlList = postImageRepository.findAllByPost(post)
+				.stream()
+				.map(PostImage::getFileUrl)
+				.collect(Collectors.toList());
+
+			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
+
+			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));


### PR DESCRIPTION
## 기능 명세
- [x] 토큰 없이 플로깅 게시글 리스트 보기
- [x] 토큰 없이 성별을 기준으로 게시글 필터링 하는 기능
- [x] 토큰 없이 나이를 기준으로 게시글 필터링 하는 기능
- [x] 토큰 없이 반려동물 여부 기준으로 게시글 필터링 하는 기능

## 결과 
[GET] /api/v1/posts/listByGender/unauth?postGender=ANY
[GET] /api/v1/posts/listByAgeRange/unauth?postAgeRangeStr=any
[GET] /api/v1/posts/listByPet/unauth?withPet=true

response는 postman에 저장해놨습니다! 

## Resolve
#23
