### PR TITLE
feat : 본인 프로필 조회 기능 구현을 구현한다.

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
@@ -28,6 +28,11 @@ public class MemberController {
         return memberService.readProfile(memberId);
     }
 
+    @GetMapping()
+    public ResponseEntity<StatusResponse> getMyProfile(@AuthUser Member member){
+        return memberService.getMyProfile(member);
+    }
+
     @PutMapping("")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<StatusResponse> updateProfile(@AuthUser Member member, @RequestBody MemberReqDto memberReqDto){

--- a/src/main/java/efub/back/jupjup/domain/member/dto/response/MyProfileResDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/response/MyProfileResDto.java
@@ -1,0 +1,34 @@
+package efub.back.jupjup.domain.member.dto.response;
+
+import efub.back.jupjup.domain.member.domain.AgeRange;
+import efub.back.jupjup.domain.member.domain.Gender;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.security.userInfo.ProviderType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyProfileResDto {
+    private Long id;
+    private String email;
+    private String profileImageUrl;
+    private String nickname;
+    private ProviderType providerType;
+    private AgeRange ageRange;
+    private Gender gender;
+    private Boolean isProfileCreated;
+
+    public static MyProfileResDto from(Member member){
+        return MyProfileResDto.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .providerType(member.getProviderType())
+                .ageRange(member.getAgeRange())
+                .gender(member.getGender())
+                .isProfileCreated(member.getModifiedAt() != null)
+                .build();
+    }
+}

--- a/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
+++ b/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
 import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
 import efub.back.jupjup.domain.member.dto.response.MemberResDto;
+import efub.back.jupjup.domain.member.dto.response.MyProfileResDto;
 import efub.back.jupjup.domain.member.dto.response.NicknameCheckResDto;
 import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
 import efub.back.jupjup.domain.member.repository.MemberRepository;
@@ -43,6 +44,11 @@ public class MemberService {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         MemberResDto memberResDto = MemberResDto.from(member);
         return make200Response(memberResDto);
+    }
+
+    public ResponseEntity<StatusResponse> getMyProfile(Member member) {
+        MyProfileResDto myProfileResDto = MyProfileResDto.from(member);
+        return make200Response(myProfileResDto);
     }
 
     public ResponseEntity<StatusResponse> checkDuplicateNickname(NicknameCheckReqDto reqDto){


### PR DESCRIPTION
## 기능 명세
- [x] access token을 이용하여 본인 프로필을 조회한다
- [x] isProfileCreated 필드를 통해 프로필 생성 여부를 확인한다

## 결과 
### [GET] /api/v1/members
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 1,
        "email": "gy5027@naver.com",
        "profileImageUrl": "https://",
        "nickname": "이화플로거",
        "providerType": "KAKAO",
        "ageRange": "AGE_20_29",
        "gender": "FEMALE",
        "isProfileCreated": true
    }
}
```

## 함께 의논할 점

## Resolve
closes : #27
