### PR TITLE
feat: 플로깅 게시글 개수 & 사용자가 참여한 게시글 개수 반환 구현

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
+++ b/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
@@ -89,6 +89,12 @@ public class PostController {
 		return postService.deletePost(member, postId);
 	}
 
+	// 전체 게시글 개수와 참여한 게시글 개수 조회
+	@GetMapping("/counts")
+	public ResponseEntity<StatusResponse> getPostCounts(@AuthUser Member member) {
+		return postService.getPostCounts(member);
+	}
+
 	@PostMapping("/images")
 	public ResponseEntity<StatusResponse> getPresignedUrls(@AuthUser Member member,
 		@RequestBody ImageUploadRequestDto imageUploadRequestDto) {

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -3,7 +3,9 @@ package efub.back.jupjup.domain.post.service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -305,5 +307,18 @@ public class PostService {
 		if (!memberId.equals(authorId)) {
 			throw new IllegalArgumentException();
 		}
+	}
+
+	// 전체 플로깅 게시글 개수와 사용자가 참여한 플로깅 게시글 개수 반환
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getPostCounts(Member member) {
+		long totalPostsCount = postRepository.count(); // 전체 플로깅 게시글의 개수
+		long joinedPostsCount = postjoinRepository.countByMember(member); // 사용자가 참여한 플로깅 게시글의 개수
+
+		Map<String, Long> counts = new HashMap<>();
+		counts.put("totalPostsCount", totalPostsCount);
+		counts.put("joinedPostsCount", joinedPostsCount);
+
+		return ResponseEntity.ok(createStatusResponse(counts));
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/postjoin/repository/PostjoinRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/postjoin/repository/PostjoinRepository.java
@@ -13,4 +13,5 @@ public interface PostjoinRepository extends JpaRepository<Postjoin, Long> {
 	Optional<Postjoin> findByMemberAndPost(Member member, Post post);
 	Boolean existsByMemberAndPost(Member member, Post post);
 	List<Postjoin> findAllByPost(Post post);
+	long countByMember(Member member);
 }


### PR DESCRIPTION
## 기능 명세
- [x] 플로깅 전체 게시글 개수
- [x] 사용자가 참여한 게시글 개수 반환 구현

## 결과 
🔻예시
### [GET] /api/v1/posts/counts
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "joinedPostsCount": 3,
        "totalPostsCount": 8
    }
}
```

## 함께 의논할 점
이 부분은 피그마의 메인 화면에서 필요한 기능 같아서 구현 하였습니다!

## Resolve
#23
