### PR TITLE
fix : 닉네임 중복 확인 기능 수정

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
@@ -1,12 +1,5 @@
 package efub.back.jupjup.domain.member.controller;
 
-import efub.back.jupjup.domain.member.domain.Member;
-import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
-import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
-import efub.back.jupjup.domain.member.service.MemberService;
-import efub.back.jupjup.domain.security.userInfo.AuthUser;
-import efub.back.jupjup.global.response.StatusResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,30 +10,40 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
+import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
+import efub.back.jupjup.domain.member.service.MemberService;
+import efub.back.jupjup.domain.security.userInfo.AuthUser;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/v1/members")
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberService memberService;
+	private final MemberService memberService;
 
-    @GetMapping("/{memberId}")
-    public ResponseEntity<StatusResponse> readProfile(@PathVariable Long memberId){
-        return memberService.readProfile(memberId);
-    }
+	@GetMapping("/{memberId}")
+	public ResponseEntity<StatusResponse> readProfile(@PathVariable Long memberId) {
+		return memberService.readProfile(memberId);
+	}
 
-    @GetMapping()
-    public ResponseEntity<StatusResponse> getMyProfile(@AuthUser Member member){
-        return memberService.getMyProfile(member);
-    }
+	@GetMapping()
+	public ResponseEntity<StatusResponse> getMyProfile(@AuthUser Member member) {
+		return memberService.getMyProfile(member);
+	}
 
-    @PutMapping("")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<StatusResponse> updateProfile(@AuthUser Member member, @RequestBody MemberReqDto memberReqDto){
-        return memberService.updateProfile(member, memberReqDto);
-    }
+	@PutMapping("")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<StatusResponse> updateProfile(@AuthUser Member member,
+		@RequestBody MemberReqDto memberReqDto) {
+		return memberService.updateProfile(member, memberReqDto);
+	}
 
-    @PostMapping("/checkNickname")
-    public ResponseEntity<StatusResponse> checkDuplicateNickname(@RequestBody NicknameCheckReqDto nicknameCheckReqDto){
-        return memberService.checkDuplicateNickname(nicknameCheckReqDto);
-    }
+	@PostMapping("/checkNickname")
+	public ResponseEntity<StatusResponse> checkDuplicateNickname(@RequestBody NicknameCheckReqDto nicknameCheckReqDto,
+		@AuthUser Member member) {
+		return memberService.checkDuplicateNickname(nicknameCheckReqDto, member);
+	}
 }

--- a/src/main/java/efub/back/jupjup/domain/member/repository/MemberRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/member/repository/MemberRepository.java
@@ -1,17 +1,21 @@
 package efub.back.jupjup.domain.member.repository;
 
-import efub.back.jupjup.domain.member.domain.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import efub.back.jupjup.domain.member.domain.Member;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-    Optional<Member> findByNickname(String nickname);
+	Optional<Member> findByEmail(String email);
 
-    boolean existsByEmail(String email);
+	Optional<Member> findByNickname(String nickname);
 
-    Optional<Member> findByUsername(String username);
+	boolean existsByEmail(String email);
 
-    boolean existsByNickname(String nickname);
+	Optional<Member> findByUsername(String username);
+
+	boolean existsByNickname(String nickname);
+
+	Long countByNickname(String nickname);
 }

--- a/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
+++ b/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
@@ -1,5 +1,10 @@
 package efub.back.jupjup.domain.member.service;
 
+import javax.transaction.Transactional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
 import efub.back.jupjup.domain.member.domain.Gender;
 import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
@@ -11,12 +16,8 @@ import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
 import efub.back.jupjup.domain.member.repository.MemberRepository;
 import efub.back.jupjup.global.response.StatusEnum;
 import efub.back.jupjup.global.response.StatusResponse;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
 
 @Service
 @Transactional
@@ -24,45 +25,49 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class MemberService {
 
-    private final MemberRepository memberRepository;
-    
-  	public Member findMemberById(Long memberId) {
-	  	  return memberRepository.findById(memberId)
-		  	    .orElseThrow(() -> new IllegalArgumentException("해당하는 멤버가 존재하지 않습니다."));
-        }
+	private final MemberRepository memberRepository;
 
-    public ResponseEntity<StatusResponse> updateProfile(Member member, MemberReqDto memberReqDto) {
-        member.updateNickname(memberReqDto.getNickname());
-        member.updateGender(Gender.valueOf(memberReqDto.getGender()));
-        member.updateProfileImage(memberReqDto.getProfileImage());
-        Member updatedMember = memberRepository.save(member);
-        MemberResDto memberResDto = MemberResDto.from(updatedMember);
-        return make200Response(memberResDto);
-    }
+	public Member findMemberById(Long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("해당하는 멤버가 존재하지 않습니다."));
+	}
 
-    public ResponseEntity<StatusResponse> readProfile(Long memberId){
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        MemberResDto memberResDto = MemberResDto.from(member);
-        return make200Response(memberResDto);
-    }
+	public ResponseEntity<StatusResponse> updateProfile(Member member, MemberReqDto memberReqDto) {
+		member.updateNickname(memberReqDto.getNickname());
+		member.updateGender(Gender.valueOf(memberReqDto.getGender()));
+		member.updateProfileImage(memberReqDto.getProfileImage());
+		Member updatedMember = memberRepository.save(member);
+		MemberResDto memberResDto = MemberResDto.from(updatedMember);
+		return make200Response(memberResDto);
+	}
 
-    public ResponseEntity<StatusResponse> getMyProfile(Member member) {
-        MyProfileResDto myProfileResDto = MyProfileResDto.from(member);
-        return make200Response(myProfileResDto);
-    }
+	public ResponseEntity<StatusResponse> readProfile(Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+		MemberResDto memberResDto = MemberResDto.from(member);
+		return make200Response(memberResDto);
+	}
 
-    public ResponseEntity<StatusResponse> checkDuplicateNickname(NicknameCheckReqDto reqDto){
-        boolean isExistingNickname = memberRepository.existsByNickname(reqDto.getNickname());
-        NicknameCheckResDto resDto = new NicknameCheckResDto(isExistingNickname);
-        return make200Response(resDto);
-    }
+	public ResponseEntity<StatusResponse> getMyProfile(Member member) {
+		MyProfileResDto myProfileResDto = MyProfileResDto.from(member);
+		return make200Response(myProfileResDto);
+	}
 
-    private ResponseEntity<StatusResponse> make200Response(Object obj){
-        return ResponseEntity.ok()
-                .body(StatusResponse.builder()
-                        .status(StatusEnum.OK.getStatusCode())
-                        .message(StatusEnum.OK.getCode())
-                        .data(obj)
-                        .build());
-    }
+	public ResponseEntity<StatusResponse> checkDuplicateNickname(NicknameCheckReqDto reqDto, Member member) {
+		Boolean isExistingNickname = null;
+		isExistingNickname = memberRepository.existsByNickname(reqDto.getNickname());
+		if (reqDto.getNickname().equals(member.getNickname())) {
+			isExistingNickname = false;
+		}
+		NicknameCheckResDto resDto = new NicknameCheckResDto(isExistingNickname);
+		return make200Response(resDto);
+	}
+
+	private ResponseEntity<StatusResponse> make200Response(Object obj) {
+		return ResponseEntity.ok()
+			.body(StatusResponse.builder()
+				.status(StatusEnum.OK.getStatusCode())
+				.message(StatusEnum.OK.getCode())
+				.data(obj)
+				.build());
+	}
 }


### PR DESCRIPTION
## 기능 명세
- [x] 카카오에서 설정된 닉네임과 같은 닉네임으로 중복 확인을 시도할 경우 isExistingNickname 값 false 리턴
- [x] 카카오 닉네임에 중복이 있을 경우 같은 닉네임으로 시도해도 isExistingNickname 값 false 리턴

## 결과 
### [GET] /api/v1/members
기존 API와 응답 형식은 동일
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "isExistingNickname": false
    }
}
```

## 함께 의논할 점
> 없으면 생략 
## Resolve
closed : #30