### PR TITLE
feat: 이미지 url 통합

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/image/controller/ImageController.java
+++ b/src/main/java/efub/back/jupjup/domain/image/controller/ImageController.java
@@ -1,0 +1,38 @@
+package efub.back.jupjup.domain.image.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import efub.back.jupjup.domain.image.service.ImageService;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
+import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
+import efub.back.jupjup.domain.security.userInfo.AuthUser;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/images")
+@RequiredArgsConstructor
+public class ImageController {
+	private final ImageService imageService;
+
+	@PostMapping
+	public ResponseEntity<StatusResponse> getPresignedUrls(
+		@AuthUser Member member,
+		@RequestBody ImageUploadRequestDto imageUploadRequestDto) {
+
+		List<ImageUploadResponseDto> presignedUrls = imageService.getPresignedUrls(
+			imageUploadRequestDto.getImageList());
+
+		StatusResponse statusResponse = imageService.createStatusResponse(presignedUrls);
+		return ResponseEntity.ok(statusResponse);
+	}
+}

--- a/src/main/java/efub/back/jupjup/domain/image/service/ImageService.java
+++ b/src/main/java/efub/back/jupjup/domain/image/service/ImageService.java
@@ -6,12 +6,15 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import efub.back.jupjup.domain.image.S3Upload;
+import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.post.domain.Post;
 import efub.back.jupjup.domain.post.domain.PostImage;
+import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
 import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
 import efub.back.jupjup.domain.post.exception.EmptyInputFilenameException;
 import efub.back.jupjup.domain.post.exception.WrongImageFormatException;
@@ -19,6 +22,8 @@ import efub.back.jupjup.domain.post.repository.PostImageRepository;
 import efub.back.jupjup.domain.report.domain.Report;
 import efub.back.jupjup.domain.report.domain.ReportImage;
 import efub.back.jupjup.domain.report.repository.ReportImageRepository;
+import efub.back.jupjup.global.response.StatusEnum;
+import efub.back.jupjup.global.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,6 +35,14 @@ public class ImageService {
 	private final S3Upload s3Upload;
 	private final PostImageRepository postImageRepository;
 	private final ReportImageRepository reportImageRepository;
+
+	public StatusResponse createStatusResponse(Object data) {
+		return StatusResponse.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(StatusEnum.OK.getCode())
+			.data(data)
+			.build();
+	}
 
 	public List<ImageUploadResponseDto> getPresignedUrls(List<String> fileNameList) {
 		return fileNameList.stream().map(raw -> {

--- a/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
+++ b/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
@@ -94,10 +94,4 @@ public class PostController {
 	public ResponseEntity<StatusResponse> getPostCounts(@AuthUser Member member) {
 		return postService.getPostCounts(member);
 	}
-
-	@PostMapping("/images")
-	public ResponseEntity<StatusResponse> getPresignedUrls(@AuthUser Member member,
-		@RequestBody ImageUploadRequestDto imageUploadRequestDto) {
-		return postService.getPresignedUrls(member, imageUploadRequestDto);
-	}
 }

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -1,8 +1,6 @@
 package efub.back.jupjup.domain.post.service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,8 +17,6 @@ import efub.back.jupjup.domain.post.domain.Post;
 import efub.back.jupjup.domain.post.domain.PostAgeRange;
 import efub.back.jupjup.domain.post.domain.PostGender;
 import efub.back.jupjup.domain.post.domain.PostImage;
-import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
-import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
 import efub.back.jupjup.domain.post.dto.PostRequestDto;
 import efub.back.jupjup.domain.post.dto.PostResponseDto;
 import efub.back.jupjup.domain.post.repository.PostImageRepository;
@@ -252,13 +248,6 @@ public class PostService {
 		postImageRepository.deleteAllByPost(post);
 		postRepository.delete(post);
 		return ResponseEntity.ok(createStatusResponse("post deleted"));
-	}
-
-	@Transactional(readOnly = true)
-	public ResponseEntity<StatusResponse> getPresignedUrls(Member member, ImageUploadRequestDto imageUploadRequestDto) {
-
-		List<ImageUploadResponseDto> urls = imageService.getPresignedUrls(imageUploadRequestDto.getImageList());
-		return ResponseEntity.ok(createStatusResponse(urls));
 	}
 
 	private void checkValidMember(Long memberId, Long authorId) {

--- a/src/main/java/efub/back/jupjup/domain/report/controller/ReportController.java
+++ b/src/main/java/efub/back/jupjup/domain/report/controller/ReportController.java
@@ -26,10 +26,4 @@ public class ReportController {
 		@AuthUser Member member) {
 		return reportService.createReport(reportRequestDto, member);
 	}
-
-	@PostMapping("/images")
-	public ResponseEntity<StatusResponse> getPresignedUrls(@AuthUser Member member,
-		@RequestBody ImageUploadRequestDto imageUploadRequestDto) {
-		return reportService.getPresignedUrls(member, imageUploadRequestDto);
-	}
 }

--- a/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
+++ b/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
@@ -45,11 +45,4 @@ public class ReportService {
 
 		return ResponseEntity.ok(createStatusResponse(reportResponseDto));
 	}
-
-	@Transactional(readOnly = true)
-	public ResponseEntity<StatusResponse> getPresignedUrls(Member member, ImageUploadRequestDto imageUploadRequestDto) {
-
-		List<ImageUploadResponseDto> urls = imageService.getPresignedUrls(imageUploadRequestDto.getImageList());
-		return ResponseEntity.ok(createStatusResponse(urls));
-	}
 }


### PR DESCRIPTION
## 기능 명세
- [x] 이미지 url 통합한다.

## 결과 
### [POST] /api/v1/images
```json
{
    "imageList" : ["image.jpg"]
}

{
    "status": 200,
    "message": "SUCCESS",
    "data": [
        {
            "rawFile": "image.jpg",
            "fileName": "42ea72a8-25a1-4b37-a998-09ab3e0f44cbimage.jpg",
            "presignedUrl": "https://jupjup-bucket.s3.ap-northeast-2.amazonaws.com/42ea72a8-25a1-4b37-a998-09ab3e0f44cbimage.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20231116T180021Z&X-Amz-SignedHeaders=host&X-Amz-Expires=119&X-Amz-Credential=AKIAR5W4MG7TYF4L3PF6%2F20231116%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=f63af31737292b72ce282b9f436e12b51012c7fd1ca4543bec4b4a07e29858df"
        }
    ]
}
```
![image](https://github.com/Lets-JUPJUP/JUPJUP-Back/assets/96541582/39e19a9a-99fe-43d6-9f86-b32cfea48e62)

## Resolve
#33 
