### PR TITLE
feat: 게시글 조회 시 찜 여부 확인 구현

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/heart/repository/HeartRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/heart/repository/HeartRepository.java
@@ -13,4 +13,5 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 	Optional<Heart> findByMemberAndPost(Member member, Post post);
 	List<Heart> findAllByMemberOrderByIdDesc(Member member);
 	Long countByMember(Member member);
+	boolean existsByMemberAndPost(Member member, Post post);
 }

--- a/src/main/java/efub/back/jupjup/domain/heart/service/HeartService.java
+++ b/src/main/java/efub/back/jupjup/domain/heart/service/HeartService.java
@@ -86,9 +86,10 @@ public class HeartService {
 				.collect(Collectors.toList());
 
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			PostResponseDto postResponseDto = PostResponseDto.of(post, imgUrlList, Optional.of(isJoined), isEnded);
+			PostResponseDto postResponseDto = PostResponseDto.of(post, imgUrlList, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 			postList.add(postResponseDto);
 		}
 

--- a/src/main/java/efub/back/jupjup/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/efub/back/jupjup/domain/post/dto/PostResponseDto.java
@@ -28,12 +28,13 @@ public class PostResponseDto {
 	private Boolean withPet;
 	private Long authorId;
 	private Optional<Boolean> isJoined; // 참여 여부를 표시하는 필드
+	private Optional<Boolean> isHearted; // 찜하기 여부를 표시하는 필드
 	private Boolean isEnded;  // 모집 마감 여부를 표시하는 필드
 	private String authorNickname;           // 글쓴이의 닉네임 필드
 	private String authorProfileImageUrl;    // 글쓴이의 프로필 이미지 URL 필드
 	private Boolean isRecruitmentSuccessful;
 
-	public static PostResponseDto of(Post post, List<String> imgUrlList, Optional<Boolean> isJoined, Boolean isEnded) {
+	public static PostResponseDto of(Post post, List<String> imgUrlList, Optional<Boolean> isJoined, Optional<Boolean> isHearted, Boolean isEnded) {
 
 		return PostResponseDto.builder()
 			.id(post.getId())
@@ -50,6 +51,7 @@ public class PostResponseDto {
 			.fileUrls(imgUrlList)
 			.withPet(post.isWithPet())
 			.authorId(post.getAuthor().getId())
+			.isHearted(isHearted)
 			.isJoined(isJoined)
 			.isEnded(isEnded)
 			.authorNickname(post.getAuthor().getNickname())

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -1,8 +1,6 @@
 package efub.back.jupjup.domain.post.service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import efub.back.jupjup.domain.heart.repository.HeartRepository;
 import efub.back.jupjup.domain.image.service.ImageService;
 import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.post.domain.Post;
@@ -39,6 +38,7 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final PostImageRepository postImageRepository;
 	private final PostjoinRepository postjoinRepository;
+	private final HeartRepository heartRepository;
 	private final ImageService imageService;
 
 	private StatusResponse createStatusResponse(Object data) {
@@ -58,8 +58,9 @@ public class PostService {
 		List<String> imageUrls = imageService.saveImageUrlsPost(requestDto.getImages(), post);
 		boolean isJoined = false;
 		boolean isEnded = false;
+		boolean isHearted = false;
 
-		PostResponseDto postResponseDto = PostResponseDto.of(post, imageUrls, Optional.of(isJoined), isEnded);
+		PostResponseDto postResponseDto = PostResponseDto.of(post, imageUrls, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 
 		return ResponseEntity.ok(createStatusResponse(postResponseDto));
 	}
@@ -75,9 +76,10 @@ public class PostService {
 			.collect(Collectors.toList());
 
 		boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+		boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 		boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-		PostResponseDto responseDto = PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+		PostResponseDto responseDto = PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 		return ResponseEntity.ok(createStatusResponse(responseDto));
 	}
 
@@ -93,9 +95,10 @@ public class PostService {
 				.collect(Collectors.toList());
 
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -114,7 +117,7 @@ public class PostService {
 
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.empty(), Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -134,9 +137,10 @@ public class PostService {
 				.collect(Collectors.toList());
 
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -157,7 +161,7 @@ public class PostService {
 
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.empty(), Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -176,9 +180,10 @@ public class PostService {
 				.collect(Collectors.toList());
 
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted),isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -198,7 +203,7 @@ public class PostService {
 
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.empty(), Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -217,9 +222,10 @@ public class PostService {
 				.collect(Collectors.toList());
 
 			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.of(isJoined), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
@@ -239,7 +245,7 @@ public class PostService {
 
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
-			return PostResponseDto.of(post, urlList, Optional.empty(), isEnded);
+			return PostResponseDto.of(post, urlList, Optional.empty(), Optional.empty(), isEnded);
 		}).collect(Collectors.toList());
 
 		return ResponseEntity.ok(createStatusResponse(responseDtos));


### PR DESCRIPTION
## 기능 명세
- [x] 게시글 조회 시 찜 여부 확인 구현

## 결과 
🔻예시
### [GET] api/v1/posts/{post_id}
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 2,
        "title": "test-title-1",
        "content": "우리 플로깅해요",
        "startPlace": "서울숲",
        "startDate": "2023-03-06T09:30:00",
        "minMember": 3,
        "maxMember": 10,
        "postGender": "FEMALE",
        "postAgeRanges": [
            "AGE_ANY"
        ],
        "dueDate": "2023-02-08T00:30:00",
        "createdAt": "2023-11-17T04:51:02.60096",
        "fileUrls": [
            "https://"
        ],
        "withPet": true,
        "authorId": 1,
        "isJoined": false,
        "isHearted": true, // 찜 여부 확인 필드 추가 
        "isEnded": true,
        "authorNickname": "채원닉네임",
        "authorProfileImageUrl": "https://",
        "isRecruitmentSuccessful": false
    }
}
```

## Resolve
#23 
