### PR TITLE
feat: 특정 사용자의 주최한 플로깅 개수, 참여한 플로깅 개수 카운트

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
+++ b/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
@@ -94,4 +94,10 @@ public class PostController {
 	public ResponseEntity<StatusResponse> getPostCounts(@AuthUser Member member) {
 		return postService.getPostCounts(member);
 	}
+
+	// 특정 사용자의 주최한 플로깅 개수와 참여한 플로깅 개수 조회
+	@GetMapping("/{memberId}/counts")
+	public ResponseEntity<StatusResponse> getUserPostCounts(@PathVariable Long memberId) {
+		return postService.getUserPostCounts(memberId);
+	}
 }

--- a/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.post.domain.Post;
 import efub.back.jupjup.domain.post.domain.PostAgeRange;
 import efub.back.jupjup.domain.post.domain.PostGender;
@@ -16,6 +17,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findAllByPostAgeRangesContaining(PostAgeRange postAgeRange);
 
 	List<Post> findAllByWithPet(boolean withPet);
+
+	long countByAuthor(Member author);
 
 	List<Post> findByDueDateBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import efub.back.jupjup.domain.heart.repository.HeartRepository;
 import efub.back.jupjup.domain.image.service.ImageService;
 import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.member.repository.MemberRepository;
 import efub.back.jupjup.domain.post.domain.Post;
 import efub.back.jupjup.domain.post.domain.PostAgeRange;
 import efub.back.jupjup.domain.post.domain.PostGender;
@@ -38,6 +39,7 @@ public class PostService {
 	private final PostjoinRepository postjoinRepository;
 	private final HeartRepository heartRepository;
 	private final ImageService imageService;
+	private final MemberRepository memberRepository;
 
 	private StatusResponse createStatusResponse(Object data) {
 		return StatusResponse.builder()
@@ -273,6 +275,20 @@ public class PostService {
 		Map<String, Long> counts = new HashMap<>();
 		counts.put("totalPostsCount", totalPostsCount);
 		counts.put("joinedPostsCount", joinedPostsCount);
+
+		return ResponseEntity.ok(createStatusResponse(counts));
+	}
+
+	// 특정 사용자의 주최한 플로깅 개수와 참여한 플로깅 개수 조회
+	public ResponseEntity<StatusResponse> getUserPostCounts(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+		long hostedPostCount = postRepository.countByAuthor(member); // 주최한 플로깅 개수
+		long joinedPostCount = postjoinRepository.countByMember(member); // 참여한 플로깅 개수
+
+		Map<String, Long> counts = new HashMap<>();
+		counts.put("hostedPostCount", hostedPostCount);
+		counts.put("joinedPostCount", joinedPostCount);
 
 		return ResponseEntity.ok(createStatusResponse(counts));
 	}


### PR DESCRIPTION
## 기능 명세
- [x] 특정 사용자의 주최한 플로깅 개수, 참여한 플로깅 개수 카운트

## 결과 

### [GET] api/v1/posts/{member_id}/counts
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "hostedPostCount": 6,
        "joinedPostCount": 1
    }
}
```


## Resolve
#23
