### PR TITLE
feat: 플로깅 게시글 관련 추가 구현 

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
+++ b/src/main/java/efub/back/jupjup/domain/post/controller/PostController.java
@@ -2,7 +2,6 @@ package efub.back.jupjup.domain.post.controller;
 
 import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.post.domain.PostAgeRange;
-import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
 import efub.back.jupjup.domain.post.dto.PostRequestDto;
 import efub.back.jupjup.domain.post.service.PostService;
 import efub.back.jupjup.domain.security.userInfo.AuthUser;
@@ -99,5 +98,11 @@ public class PostController {
 	@GetMapping("/{memberId}/counts")
 	public ResponseEntity<StatusResponse> getUserPostCounts(@PathVariable Long memberId) {
 		return postService.getUserPostCounts(memberId);
+	}
+
+	// 로그인한 사용자가 주최한 게시글 리스트 조회
+	@GetMapping("/hosted")
+	public ResponseEntity<StatusResponse> getHostedPosts(@AuthUser Member member) {
+		return postService.getHostedPosts(member);
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/post/exception/MaxMemberLimitException.java
+++ b/src/main/java/efub/back/jupjup/domain/post/exception/MaxMemberLimitException.java
@@ -1,0 +1,6 @@
+package efub.back.jupjup.domain.post.exception;
+
+import efub.back.jupjup.global.exception.custom.BadRequestException;
+
+public class MaxMemberLimitException extends BadRequestException {
+}

--- a/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
@@ -20,5 +20,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	long countByAuthor(Member author);
 
+	List<Post> findAllByAuthor(Member author);
+
 	List<Post> findByDueDateBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -56,7 +56,7 @@ public class PostService {
 		postRepository.save(post);
 
 		List<String> imageUrls = imageService.saveImageUrlsPost(requestDto.getImages(), post);
-		boolean isJoined = false;
+		boolean isJoined = true;
 		boolean isEnded = false;
 		boolean isHearted = false;
 
@@ -75,7 +75,9 @@ public class PostService {
 			.map(PostImage::getFileUrl)
 			.collect(Collectors.toList());
 
-		boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+		boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+		boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+		boolean isJoined = isAuthor || hasJoined;
 		boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 		boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
@@ -94,7 +96,9 @@ public class PostService {
 				.map(PostImage::getFileUrl)
 				.collect(Collectors.toList());
 
-			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+			boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isJoined = isAuthor || hasJoined;
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
@@ -136,7 +140,9 @@ public class PostService {
 				.map(PostImage::getFileUrl)
 				.collect(Collectors.toList());
 
-			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+			boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isJoined = isAuthor || hasJoined;
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
@@ -179,7 +185,9 @@ public class PostService {
 				.map(PostImage::getFileUrl)
 				.collect(Collectors.toList());
 
-			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+			boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isJoined = isAuthor || hasJoined;
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 
@@ -221,7 +229,9 @@ public class PostService {
 				.map(PostImage::getFileUrl)
 				.collect(Collectors.toList());
 
-			boolean isJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+			boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+			boolean isJoined = isAuthor || hasJoined;
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -314,8 +314,9 @@ public class PostService {
 					.map(PostImage::getFileUrl)
 					.collect(Collectors.toList());
 
-				boolean isAuthor = post.getAuthor().equals(member);
-				boolean isJoined = isAuthor || postjoinRepository.existsByMemberAndPost(member, post);
+				boolean isAuthor = member.getId().equals(post.getAuthor().getId());
+				boolean hasJoined = postjoinRepository.existsByMemberAndPost(member, post);
+				boolean isJoined = isAuthor || hasJoined;
 				boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 				boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 

--- a/src/main/java/efub/back/jupjup/domain/postjoin/service/PostjoinService.java
+++ b/src/main/java/efub/back/jupjup/domain/postjoin/service/PostjoinService.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PostjoinService {
 	private static final String RECRUITMENT_SUCCESS_MSG = "신청한 플로깅 모임이 인원을 충족하여 성사되었습니다.";
-	private static final String RECRUITMENT_FAILURE_MSG = "신청한 플로깅 모임이 인원을 불총족하여 취소되었습니다.";
+	private static final String RECRUITMENT_FAILURE_MSG = "신청한 플로깅 모임이 인원을 불충족하여 취소되었습니다.";
 	private final PostRepository postRepository;
 	private final PostjoinRepository postjoinRepository;
 	private final NotificationService notificationService;

--- a/src/main/java/efub/back/jupjup/domain/postjoin/service/PostjoinService.java
+++ b/src/main/java/efub/back/jupjup/domain/postjoin/service/PostjoinService.java
@@ -14,6 +14,7 @@ import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.notification.comment.domain.NotificationType;
 import efub.back.jupjup.domain.notification.service.NotificationService;
 import efub.back.jupjup.domain.post.domain.Post;
+import efub.back.jupjup.domain.post.exception.MaxMemberLimitException;
 import efub.back.jupjup.domain.post.repository.PostRepository;
 import efub.back.jupjup.domain.postjoin.domain.Postjoin;
 import efub.back.jupjup.domain.postjoin.dto.MemberProfileResponseDto;
@@ -41,7 +42,11 @@ public class PostjoinService {
 			.orElseThrow(() -> new IllegalArgumentException("해당 게시글을 찾을 수 없습니다."));
 		Long memberCount = postjoinRepository.countByPost(post);
 
-		// TODO : 최대 인원을 초과할 경우 예외 발생시키는 로직 추가 (memberCount 이용)
+		// 최대 인원을 초과할 경우 예외 발생
+		Long maxMember = new Long(post.getMaxMember());
+		if (memberCount >= maxMember - 1) {
+			throw new MaxMemberLimitException();
+		}
 
 		Postjoin postjoin = new Postjoin(member, post, true);
 		postjoinRepository.save(postjoin);

--- a/src/main/java/efub/back/jupjup/global/exception/ExceptionType.java
+++ b/src/main/java/efub/back/jupjup/global/exception/ExceptionType.java
@@ -8,6 +8,7 @@ import efub.back.jupjup.domain.auth.exception.RefreshTokenNotValidException;
 import efub.back.jupjup.domain.member.exception.InvalidNicknameException;
 import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
 import efub.back.jupjup.domain.notification.exception.NotificationNotFoundException;
+import efub.back.jupjup.domain.post.exception.MaxMemberLimitException;
 import efub.back.jupjup.domain.post.exception.PostNotFoundException;
 import efub.back.jupjup.domain.review.exception.BadgeNotExistsForCodeException;
 import efub.back.jupjup.domain.review.exception.ReviewNotAllowedException;
@@ -48,7 +49,8 @@ public enum ExceptionType {
 	NOTIFICATION_NOT_FOUND_EXCEPTION("C5000", "해당 알림을 찾을 수 없습니다.", NotificationNotFoundException.class),
 
 	// 게시글 관련 - C6***
-	POST_NOT_FOUND_EXCEPTION("C6000", "존재하지 않는 게시글입니다.", PostNotFoundException.class);
+	POST_NOT_FOUND_EXCEPTION("C6000", "존재하지 않는 게시글입니다.", PostNotFoundException.class),
+	MAX_MEMBER_LIMIT_EXCEPTION("C6001", "최대 인원을 초과하여 참여할 수 없습니다.", MaxMemberLimitException.class);
 
 	private final String errorCode;
 	private final String message;


### PR DESCRIPTION
## 기능 명세
- [ ]  사용자가 주최한 플로깅 게시글 목록 조회 구현
- [ ] isJoined에서 플로깅 작성자 본인은 참여버튼을 누르지 않아도 true로 설정되도록 로직 수정

## 결과 
- postman에 예시 저장하였습니다! 

## 함께 의논할 점
 isJoined에서 플로깅 작성자 본인은 참여버튼을 누르지 않아도 true로 설정되도록 로직 수정
-> 이 부분 로직이 잘 작성되었는지 확인 부탁드리겠습니다! 작성자 아이디와 로그인한 사용자 아이디를 비교하여 같으면 true 반환하도록 하였습니다. 

## Resolve
#23 
