### PR TITLE
feat: 공식행사(EventInfo) 상세보기에 참여여부(Joined) 반환

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/eventInfo/controller/EventInfoController.java
+++ b/src/main/java/efub/back/jupjup/domain/eventInfo/controller/EventInfoController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import efub.back.jupjup.domain.eventInfo.service.EventInfoService;
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.security.userInfo.AuthUser;
 import efub.back.jupjup.global.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,8 +22,8 @@ public class EventInfoController {
 
 	// 공식행사 게시글 상세 조회
 	@GetMapping("/{eventInfoId}")
-	public ResponseEntity<StatusResponse> getEventInfo(@PathVariable Long eventInfoId){
-		return eventInfoService.getEventInfo(eventInfoId);
+	public ResponseEntity<StatusResponse> getEventInfo(@PathVariable Long eventInfoId, @AuthUser Member member){
+		return eventInfoService.getEventInfo(eventInfoId, member);
 	}
 
 	// 공식행사 게시글 리스트 조회

--- a/src/main/java/efub/back/jupjup/domain/eventInfo/dto/EventInfoResponseDto.java
+++ b/src/main/java/efub/back/jupjup/domain/eventInfo/dto/EventInfoResponseDto.java
@@ -11,6 +11,7 @@ public class EventInfoResponseDto {
 	private String title;
 	private String infoUrl;
 	private String imageUrl;
+	private boolean isJoined; // 참여 여부
 
 	public static EventInfoResponseDto of(EventInfo eventInfo) {
 		return EventInfoResponseDto.builder()
@@ -18,6 +19,17 @@ public class EventInfoResponseDto {
 			.title(eventInfo.getTitle())
 			.infoUrl(eventInfo.getInfoUrl())
 			.imageUrl(eventInfo.getImageUrl())
+			.isJoined(false)
+			.build();
+	}
+
+	public static EventInfoResponseDto of(EventInfo eventInfo, boolean isJoined) {
+		return EventInfoResponseDto.builder()
+			.id(eventInfo.getId())
+			.title(eventInfo.getTitle())
+			.infoUrl(eventInfo.getInfoUrl())
+			.imageUrl(eventInfo.getImageUrl())
+			.isJoined(isJoined)
 			.build();
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/eventInfo/service/EventInfoService.java
+++ b/src/main/java/efub/back/jupjup/domain/eventInfo/service/EventInfoService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 import efub.back.jupjup.domain.eventInfo.domain.EventInfo;
 import efub.back.jupjup.domain.eventInfo.dto.EventInfoResponseDto;
 import efub.back.jupjup.domain.eventInfo.repository.EventInfoRepository;
+import efub.back.jupjup.domain.eventjoin.repository.EventjoinRepository;
+import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.global.response.StatusEnum;
 import efub.back.jupjup.global.response.StatusResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class EventInfoService {
 	private final EventInfoRepository eventInfoRepository;
+	private final EventjoinRepository eventjoinRepository;
 
 	private StatusResponse createStatusResponse(Object data) {
 		return StatusResponse.builder()
@@ -29,21 +32,23 @@ public class EventInfoService {
 			.data(data)
 			.build();
 	}
-
 	// 공식 행사 상세 보기 : 1개
 	@Transactional(readOnly = true)
-	public ResponseEntity<StatusResponse> getEventInfo(Long eventInfoId){
+	public ResponseEntity<StatusResponse> getEventInfo(Long eventInfoId, Member member){
 		EventInfo eventInfo = eventInfoRepository.findById(eventInfoId).orElseThrow();
-		EventInfoResponseDto responseDto = EventInfoResponseDto.of(eventInfo);
+
+		boolean isJoined = eventjoinRepository.findByMemberAndEventInfo(member, eventInfo).isPresent();
+		EventInfoResponseDto responseDto = EventInfoResponseDto.of(eventInfo, isJoined);
 		return ResponseEntity.ok(createStatusResponse(responseDto));
 	}
+
 
 	// 공식 행사 리스트 보기
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getAllEventInfos() {
 		List<EventInfo> eventInfos = eventInfoRepository.findAll();
 		List<EventInfoResponseDto> responseDtos = eventInfos.stream()
-			.map(EventInfoResponseDto::of)
+			.map(eventInfo -> EventInfoResponseDto.of(eventInfo))
 			.collect(Collectors.toList());
 		return ResponseEntity.ok(createStatusResponse(responseDtos));
 	}


### PR DESCRIPTION
## 기능 명세
- [x] 공식행사(EventInfo) 상세보기에 참여여부(Joined) 반환

## 결과 
🔻예시
### [GET] /api/v1/eventInfos/2
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 2,
        "title": "공식행사 제목 (2)",
        "infoUrl": "https://example.com/images.png",
        "imageUrl": "https://www.sd.go.kr/main/selectBbsNttView.do?bbsNo=183&nttNo=332084&&pageUnit=10&key=1472&pageIndex=2",
        "joined": true
    }
}
```

## 함께 의논할 점
> 공식행사 리스트는 토큰없이 볼 수있어야해서 참여여부는 모두 false로 반환하였습니다. 상세 정보에서 사용자의  참여 여부를 확인할 수 있습니다.

## Resolve
#14 