### PR TITLE
fix: 게시글 리스트 순서 변경

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package efub.back.jupjup.domain.post.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import efub.back.jupjup.domain.member.domain.Member;
@@ -12,15 +13,15 @@ import efub.back.jupjup.domain.post.domain.PostGender;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-	List<Post> findAllByPostGender(PostGender postGender);
+	List<Post> findAllByPostGender(PostGender postGender, Sort sort);
 
-	List<Post> findAllByPostAgeRangesContaining(PostAgeRange postAgeRange);
+	List<Post> findAllByPostAgeRangesContaining(PostAgeRange postAgeRange, Sort sort);
 
-	List<Post> findAllByWithPet(boolean withPet);
+	List<Post> findAllByWithPet(boolean withPet, Sort sort);
 
 	long countByAuthor(Member author);
 
-	List<Post> findAllByAuthor(Member author);
+	List<Post> findAllByAuthor(Member author, Sort sort);
 
 	List<Post> findByDueDateBetween(LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,7 +91,7 @@ public class PostService {
 	// 플로깅 게시글 리스트 보기
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getAllPosts(Member member) {
-		List<Post> posts = postRepository.findAll();
+		List<Post> posts = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -113,7 +114,7 @@ public class PostService {
 	// 플로깅 게시글 리스트 보기 - (로그인 없이)
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getAllPostsUnAuth() {
-		List<Post> posts = postRepository.findAll();
+		List<Post> posts = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -134,7 +135,7 @@ public class PostService {
 	public ResponseEntity<StatusResponse> getPostsByGender(String postGenderStr, Member member) {
 
 		PostGender postGender = PostGender.valueOf(postGenderStr.toUpperCase());
-		List<Post> posts = postRepository.findAllByPostGender(postGender);
+		List<Post> posts = postRepository.findAllByPostGender(postGender, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -159,7 +160,7 @@ public class PostService {
 	public ResponseEntity<StatusResponse> getPostsByGenderUnAuth(String postGenderStr) {
 
 		PostGender postGender = PostGender.valueOf(postGenderStr.toUpperCase());
-		List<Post> posts = postRepository.findAllByPostGender(postGender);
+		List<Post> posts = postRepository.findAllByPostGender(postGender, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -179,7 +180,7 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getPostsByAgeRange(PostAgeRange postAge, Member member) {
 
-		List<Post> posts = postRepository.findAllByPostAgeRangesContaining(postAge);
+		List<Post> posts = postRepository.findAllByPostAgeRangesContaining(postAge, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -203,7 +204,7 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getPostsByAgeRangeUnAuth(PostAgeRange postAge) {
 
-		List<Post> posts = postRepository.findAllByPostAgeRangesContaining(postAge);
+		List<Post> posts = postRepository.findAllByPostAgeRangesContaining(postAge, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -223,7 +224,7 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getPostsByWithPet(boolean withPetValue, Member member) {
 
-		List<Post> posts = postRepository.findAllByWithPet(withPetValue);
+		List<Post> posts = postRepository.findAllByWithPet(withPetValue, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -247,7 +248,7 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getPostsByWithPetUnAuth(boolean withPetValue) {
 
-		List<Post> posts = postRepository.findAllByWithPet(withPetValue);
+		List<Post> posts = postRepository.findAllByWithPet(withPetValue, Sort.by(Sort.Direction.DESC, "createdAt"));
 
 		List<PostResponseDto> responseDtos = posts.stream().map(post -> {
 			List<String> urlList = postImageRepository.findAllByPost(post)
@@ -308,7 +309,7 @@ public class PostService {
 	// 로그인한 사용자가 주최한 플로깅 게시글을 조회하는 메소드
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getHostedPosts(Member member) {
-		List<Post> hostedPosts = postRepository.findAllByAuthor(member);
+		List<Post> hostedPosts = postRepository.findAllByAuthor(member, Sort.by(Sort.Direction.DESC, "createdAt"));
 		List<PostResponseDto> hostedPostsDtos = hostedPosts.stream()
 			.map(post -> {
 				List<String> urlList = postImageRepository.findAllByPost(post)
@@ -332,7 +333,7 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public ResponseEntity<StatusResponse> getJoinedPosts(Member member) {
 
-		List<Postjoin> joinedPostjoins = postjoinRepository.findByMember(member);
+		List<Postjoin> joinedPostjoins = postjoinRepository.findByMemberOrderByPostCreatedAtDesc(member);
 
 		LocalDateTime now = LocalDateTime.now();
 		List<PostResponseDto> activePosts = new ArrayList<>();

--- a/src/main/java/efub/back/jupjup/domain/postjoin/repository/PostjoinRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/postjoin/repository/PostjoinRepository.java
@@ -25,4 +25,6 @@ public interface PostjoinRepository extends JpaRepository<Postjoin, Long> {
 
 	@Query("SELECT p.member.id FROM Postjoin p WHERE p.post.Id = :postId")
 	List<Long> findMemberIdsByPostId(@Param("postId") Long postId);
+
+	List<Postjoin> findByMemberOrderByPostCreatedAtDesc(Member member);
 }


### PR DESCRIPTION
## 기능 명세
- [x] 플로깅 게시글 리스트 최신순으로 보기
- [x] 성별을 기준으로 게시글 필터링 하는 기능 최신순으로 보기
- [x] 나이를 기준으로 게시글 필터링 하는 기능 최신순으로 보기
- [x] 반려동물 여부 기준으로 게시글 필터링 하는 기능 최신순으로 보기
- [x] 로그인한 사용자가 주최한 플로깅 게시글을 최신순으로 보기
- [x] 로그인한 사용자가 참여한 플로깅 게시글을 최신순으로 보기

## Resolve
#39
