### PR TITLE
fix: 이미지 없이 신고 가능하도록 수정

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
+++ b/src/main/java/efub/back/jupjup/domain/report/service/ReportService.java
@@ -1,5 +1,6 @@
 package efub.back.jupjup.domain.report.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -8,8 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import efub.back.jupjup.domain.image.service.ImageService;
 import efub.back.jupjup.domain.member.domain.Member;
-import efub.back.jupjup.domain.post.dto.ImageUploadRequestDto;
-import efub.back.jupjup.domain.post.dto.ImageUploadResponseDto;
 import efub.back.jupjup.domain.report.domain.Report;
 import efub.back.jupjup.domain.report.dto.ReportRequestDto;
 import efub.back.jupjup.domain.report.dto.ReportResponseDto;
@@ -40,8 +39,11 @@ public class ReportService {
 		Report report = reportRequestDto.toEntity(reportRequestDto, member);
 		reportRepository.save(report);
 
-		List<String> imageUrls = imageService.saveImageUrlsReport(reportRequestDto.getImages(), report);
-		ReportResponseDto reportResponseDto = ReportResponseDto.of(report,imageUrls);
+		List<String> imageUrls = new ArrayList<>();
+		if (reportRequestDto.getImages() != null && !reportRequestDto.getImages().isEmpty()) {
+			imageUrls = imageService.saveImageUrlsReport(reportRequestDto.getImages(), report);
+		}
+		ReportResponseDto reportResponseDto = ReportResponseDto.of(report, imageUrls);
 
 		return ResponseEntity.ok(createStatusResponse(reportResponseDto));
 	}


### PR DESCRIPTION
## 기능 명세
- [ ] 이미지 없이도 신고 가능하도록 수정

## 결과 
🔻이미지 null로 request하였을 때, response 예시
### [POST] /api/v1/reports
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 3,
        "writerId": 1,
        "targetId": 6,
        "content": "신고사유 작성",
        "fileUrls": [],
        "createdDate": "2023-11-25T03:30:17.5623854"
    }
}
```

## Resolve
#12 
