### PR TITLE
fix : 알림 조회 최신순 정렬 적용

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/notification/repository/NotificationRepository.java
@@ -11,10 +11,12 @@ import efub.back.jupjup.domain.notification.domain.Notification;
 import efub.back.jupjup.domain.notification.domain.NotificationType;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-	Page<Notification> findAllByReceiverIdAndNotificationTypeIn(Long receiverId, List<NotificationType> types,
+	Page<Notification> findAllByReceiverIdAndNotificationTypeInOrderByCreatedAtDesc(Long receiverId,
+		List<NotificationType> types,
 		Pageable pageable);
 
-	List<Notification> findAllByReceiverIdAndNotificationTypeIn(Long receiverId, List<NotificationType> types);
+	List<Notification> findAllByReceiverIdAndNotificationTypeInOrderByCreatedAtDesc(Long receiverId,
+		List<NotificationType> types);
 
 	long countByIsReadFalseAndReceiverAndNotificationTypeIn(Member receiver, List<NotificationType> types);
 }

--- a/src/main/java/efub/back/jupjup/domain/notification/service/NotificationService.java
+++ b/src/main/java/efub/back/jupjup/domain/notification/service/NotificationService.java
@@ -110,7 +110,8 @@ public class NotificationService {
 		List<NotificationType> types = Arrays.asList(NotificationType.PLOGGING, NotificationType.REPLY,
 			NotificationType.COMMENT);
 		PageRequest pageRequest = PageRequest.of(page, size);
-		Page<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeIn(memberId,
+		Page<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeInOrderByCreatedAtDesc(
+			memberId,
 			types, pageRequest);
 		List<NotificationResDto> notificationResDtos = notifications.stream()
 			.map(NotificationResDto::create)
@@ -125,7 +126,8 @@ public class NotificationService {
 	public ResponseEntity<StatusResponse> findAllNotification(Long memberId) {
 		List<NotificationType> types = Arrays.asList(NotificationType.PLOGGING, NotificationType.REPLY,
 			NotificationType.COMMENT);
-		List<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeIn(memberId,
+		List<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeInOrderByCreatedAtDesc(
+			memberId,
 			types);
 		List<NotificationResDto> notificationResDtos = notifications.stream()
 			.map(NotificationResDto::create)
@@ -139,7 +141,7 @@ public class NotificationService {
 		List<NotificationType> types = Arrays.asList(NotificationType.PLOGGING, NotificationType.REPLY,
 			NotificationType.COMMENT);
 
-		List<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeIn(
+		List<Notification> notifications = notificationRepository.findAllByReceiverIdAndNotificationTypeInOrderByCreatedAtDesc(
 			member.getId(), types);
 		for (Notification notification : notifications) {
 			notification.read();


### PR DESCRIPTION
## 기능 명세
- [x] 알림 조회 API 응답값에 최신순 정렬을 적용한다.

## 결과 
### [GET] /api/v1/notifications/list
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": [
        {
            "id": 37,
            "content": "참여자 중 쓰레기봉투 필요하신분 나눔해요!",
            "contentId": 1,
            "isRead": true,
            "notificationType": "COMMENT",
            "time": "2023-11-23T13:13:49"
        },
        {
            "id": 36,
            "content": "재미있어 보여요",
            "contentId": 1,
            "isRead": true,
            "notificationType": "COMMENT",
            "time": "2023-11-23T13:12:37"
        }
    ]
}
```

## 함께 의논할 점
> 없으면 생략 
## Resolve
closes : #59 
