### PR TITLE
feat : 탈퇴 회원에 대한 정보 처리 방식 수정

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
+++ b/src/main/java/efub/back/jupjup/domain/member/domain/Member.java
@@ -23,6 +23,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member extends BaseTimeEntity {
 	public static final String INFO_UNKNOWN = "unknown";
+	public static final String WITHDRAWN_NICKNAME = "(탈퇴한 회원)";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "member_id", updatable = false)
@@ -75,7 +77,7 @@ public class Member extends BaseTimeEntity {
 
 	public boolean validateNickName(String nickname) {
 		if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches(
-			"[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
+			"[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equals(WITHDRAWN_NICKNAME)) {
 			throw new InvalidNicknameException();
 		} else {
 			return true;
@@ -127,7 +129,7 @@ public class Member extends BaseTimeEntity {
 	}
 
 	public void withdrawInfoProcess() {
-		this.nickname = INFO_UNKNOWN;
+		this.nickname = WITHDRAWN_NICKNAME;
 		this.email = INFO_UNKNOWN;
 		this.username = INFO_UNKNOWN;
 		this.providerType = null;

--- a/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
+++ b/src/main/java/efub/back/jupjup/domain/member/service/MemberService.java
@@ -58,10 +58,17 @@ public class MemberService {
 
 	public ResponseEntity<StatusResponse> checkDuplicateNickname(NicknameCheckReqDto reqDto, Member member) {
 		Boolean isExistingNickname = null;
-		isExistingNickname = memberRepository.existsByNickname(reqDto.getNickname());
-		if (reqDto.getNickname().equals(member.getNickname())) {
+		String nickname = reqDto.getNickname();
+		isExistingNickname = memberRepository.existsByNickname(nickname);
+
+		// 자신의 기존 닉네임과 같은 닉네임인 경우
+		if (nickname.equals(member.getNickname())) {
 			isExistingNickname = false;
 		}
+		if (nickname.equals(Member.WITHDRAWN_NICKNAME)) {
+			isExistingNickname = true;
+		}
+		
 		NicknameCheckResDto resDto = new NicknameCheckResDto(isExistingNickname);
 		return make200Response(resDto);
 	}

--- a/src/main/java/efub/back/jupjup/domain/security/service/CustomOAuth2UserService.java
+++ b/src/main/java/efub/back/jupjup/domain/security/service/CustomOAuth2UserService.java
@@ -58,6 +58,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 				if (!memberRepository.existsByEmail(oAuth2UserInfo.getEmail())) {
 					String nickname = oAuth2UserInfo.getNickname();
 					log.info("카카오 닉네임 : " + nickname);
+
+					// 카카오에서 최초로 설정되는 닉네임이 유효하지 않은 경우 랜덤값으로 저장
 					if (invalidateNickname(nickname)) {
 						nickname = String.valueOf(System.currentTimeMillis());
 					}
@@ -95,7 +97,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 	public boolean invalidateNickname(String nickname) {
 		if (Objects.isNull(nickname) || nickname.isBlank() || nickname.length() > 15 || !nickname.matches(
-			"[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equalsIgnoreCase(INFO_UNKNOWN)) {
+			"[ㄱ-ㅎ가-힣a-zA-Z0-9_]+") || nickname.equals(WITHDRAWN_NICKNAME)) {
 			return true;
 		}
 


### PR DESCRIPTION
## 기능 명세
- [x] 탈퇴 회원의 경우 닉네임을 "(탈퇴한 회원)"으로 변경하도록 수정한다.
- [x] 유저 닉네임으로 "(탈퇴한 회원)"을 사용할 수 없다.

## 결과 
api 요청/응답 형식에는 변화 없음

## 함께 의논할 점
> 없으면 생략 
## Resolve
closes : #61