### PR TITLE
feat : 쓰레기통별 피드백 이력 조회 기능 추가

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
@@ -34,8 +34,8 @@ public class TrashCanController {
 		return trashCanService.writeFeedback(member, feedbackReqDto);
 	}
 
-	@GetMapping("/feedbacks/{trashcanId}")
-	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member, @PathVariable Long trashcanId) {
-		return trashCanService.findFeedbacks(member, trashcanId);
+	@GetMapping("/feedbacks/{trashCanId}")
+	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member, @PathVariable Long trashCanId) {
+		return trashCanService.findFeedbacks(member, trashCanId);
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
@@ -2,6 +2,7 @@ package efub.back.jupjup.domain.trashCan.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,8 +34,8 @@ public class TrashCanController {
 		return trashCanService.writeFeedback(member, feedbackReqDto);
 	}
 
-	@GetMapping("/feedbacks")
-	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member) {
-		return trashCanService.findFeedbacks(member);
+	@GetMapping("/feedbacks/{trashcanId}")
+	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member, @PathVariable Long trashcanId) {
+		return trashCanService.findFeedbacks(member, trashcanId);
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/trashCan/repository/BinFeedbackRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/repository/BinFeedbackRepository.java
@@ -8,5 +8,5 @@ import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.trashCan.domain.BinFeedback;
 
 public interface BinFeedbackRepository extends JpaRepository<BinFeedback, Long> {
-	List<BinFeedback> findAllByMember(Member member);
+	List<BinFeedback> findAllByMemberAndTrashCanId(Member member, Long trashCanId);
 }

--- a/src/main/java/efub/back/jupjup/domain/trashCan/service/TrashCanService.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/service/TrashCanService.java
@@ -84,8 +84,11 @@ public class TrashCanService {
 	}
 
 	public ResponseEntity<StatusResponse> findFeedbacks(Member member, Long trashcanId) {
-		List<BinFeedback> binFeedbacks = binFeedbackRepository.findAllByMember(member);
+		if (!trashCanRepository.existsById(trashcanId)) {
+			throw new TrashCanNotFoundException();
+		}
 
+		List<BinFeedback> binFeedbacks = binFeedbackRepository.findAllByMemberAndTrashCanId(member, trashcanId);
 		Map<Integer, Boolean> feedbackExistsMap = new HashMap<>();
 		for (Feedback feedback : Feedback.values()) {
 			boolean feedbackExists = binFeedbacks.stream()

--- a/src/main/java/efub/back/jupjup/domain/trashCan/service/TrashCanService.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/service/TrashCanService.java
@@ -1,7 +1,8 @@
 package efub.back.jupjup.domain.trashCan.service;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -11,14 +12,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import efub.back.jupjup.domain.member.domain.Member;
-import efub.back.jupjup.domain.security.userInfo.AuthUser;
 import efub.back.jupjup.domain.trashCan.domain.BinFeedback;
 import efub.back.jupjup.domain.trashCan.domain.Direction;
 import efub.back.jupjup.domain.trashCan.domain.Feedback;
 import efub.back.jupjup.domain.trashCan.domain.TrashCan;
 import efub.back.jupjup.domain.trashCan.dto.Location;
 import efub.back.jupjup.domain.trashCan.dto.request.FeedbackReqDto;
-import efub.back.jupjup.domain.trashCan.dto.response.FeedbackListResDto;
 import efub.back.jupjup.domain.trashCan.dto.response.FeedbackResDto;
 import efub.back.jupjup.domain.trashCan.dto.response.TrashCansResDto;
 import efub.back.jupjup.domain.trashCan.exception.TrashCanNotFoundException;
@@ -84,17 +83,18 @@ public class TrashCanService {
 		return make200Response(resDto);
 	}
 
-	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member) {
+	public ResponseEntity<StatusResponse> findFeedbacks(Member member, Long trashcanId) {
 		List<BinFeedback> binFeedbacks = binFeedbackRepository.findAllByMember(member);
-		List<FeedbackResDto> feedbackResDtos = new ArrayList<>();
-		for (BinFeedback binFeedback : binFeedbacks) {
-			FeedbackResDto feedbackResDto = FeedbackResDto.from(binFeedback);
-			feedbackResDtos.add(feedbackResDto);
+
+		Map<Integer, Boolean> feedbackExistsMap = new HashMap<>();
+		for (Feedback feedback : Feedback.values()) {
+			boolean feedbackExists = binFeedbacks.stream()
+				.anyMatch(binFeedback -> binFeedback.getFeedback() == feedback);
+			feedbackExistsMap.put(feedback.getCode(), feedbackExists);
+
 		}
 
-		Integer size = binFeedbacks.size();
-		FeedbackListResDto resDto = new FeedbackListResDto(size, feedbackResDtos);
-		return make200Response(resDto);
+		return make200Response(feedbackExistsMap);
 	}
 
 	private ResponseEntity<StatusResponse> make200Response(Object obj) {


### PR DESCRIPTION
## 기능 명세
- [x] 쓰레기통별 피드백 이력 조회
## 결과 
### [GET] /api/v1/trashCans/feedbacks/{trashcanId}
- 특정 유저가 특정 쓰레기통에 대해 각각의 피드백 타입별로 제출한 이력이 있는지 조회
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "0": false,
        "1": false,
        "2": true,
        "3": false,
        "4": false,
        "5": false,
        "6": false,
        "7": false,
        "8": false,
        "9": false
    }
}
```

## 함께 의논할 점
> 없으면 생략 
## Resolve
closes : #56 
