### PR TITLE
feat : 쓰레기통 리뷰 중복 방지를 위한 기능 구현

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/controller/TrashCanController.java
@@ -35,7 +35,7 @@ public class TrashCanController {
 	}
 
 	@GetMapping("/feedbacks/{trashCanId}")
-	public ResponseEntity<StatusResponse> findFeedbacks(@AuthUser Member member, @PathVariable Long trashCanId) {
-		return trashCanService.findFeedbacks(member, trashCanId);
+	public ResponseEntity<StatusResponse> findFeedback(@AuthUser Member member, @PathVariable Long trashCanId) {
+		return trashCanService.findFeedback(member, trashCanId);
 	}
 }

--- a/src/main/java/efub/back/jupjup/domain/trashCan/domain/Feedback.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/domain/Feedback.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum Feedback {
 	NEEDS_MAINTENANCE(0, "관리 필요"),
 	NORMAL(1, "보통"),
-	EXCELLENT(2, "우수");
+	EXCELLENT(2, "우수"),
+	UNDEFINED(3, "존재하지 않음");
 
 	private final Integer code;
 	private final String description;

--- a/src/main/java/efub/back/jupjup/domain/trashCan/exception/FeedbackAlreadyExistsException.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/exception/FeedbackAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package efub.back.jupjup.domain.trashCan.exception;
+
+import efub.back.jupjup.global.exception.custom.BadRequestException;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class FeedbackAlreadyExistsException extends BadRequestException {
+}

--- a/src/main/java/efub/back/jupjup/domain/trashCan/repository/BinFeedbackRepository.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/repository/BinFeedbackRepository.java
@@ -1,6 +1,7 @@
 package efub.back.jupjup.domain.trashCan.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,7 +12,9 @@ import efub.back.jupjup.domain.trashCan.domain.BinFeedback;
 import efub.back.jupjup.domain.trashCan.domain.Feedback;
 
 public interface BinFeedbackRepository extends JpaRepository<BinFeedback, Long> {
-	List<BinFeedback> findAllByMemberAndTrashCanId(Member member, Long trashCanId);
+	Optional<BinFeedback> findBinFeedbackByMemberAndTrashCanId(Member member, Long trashCanId);
+
+	Boolean existsBinFeedbackByMemberAndTrashCanId(Member member, Long trashCanId);
 
 	List<BinFeedback> findAllByTrashCanId(Long trashCanId);
 

--- a/src/main/java/efub/back/jupjup/global/exception/ExceptionType.java
+++ b/src/main/java/efub/back/jupjup/global/exception/ExceptionType.java
@@ -26,6 +26,7 @@ import efub.back.jupjup.domain.score.exception.NotValidScoreException;
 import efub.back.jupjup.domain.score.exception.ScoringNotAllowedException;
 import efub.back.jupjup.domain.security.exception.BlockedAccountException;
 import efub.back.jupjup.domain.security.exception.ExpiredTokenException;
+import efub.back.jupjup.domain.trashCan.exception.FeedbackAlreadyExistsException;
 import efub.back.jupjup.domain.trashCan.exception.FeedbackNotExistsForCodeException;
 import efub.back.jupjup.domain.trashCan.exception.TrashCanNotFoundException;
 import efub.back.jupjup.global.exception.custom.ApplicationException;
@@ -61,6 +62,7 @@ public enum ExceptionType {
 	FEEDBACK_NOT_EXISTS_FOR_CODE_EXCEPTION("C4000", "해당 코드와 일치하는 쓰레기통 피드백이 존재하지 않습니다.",
 		FeedbackNotExistsForCodeException.class),
 	TRASHCAN_NOT_FOUND_EXCEPTION("C4001", "존재하지 않는 쓰레기통입니다.", TrashCanNotFoundException.class),
+	FEEDBACK_ALREADY_EXISTS_EXCEPTION("C4002", "이미 쓰레기통 리뷰를 완료했습니다.", FeedbackAlreadyExistsException.class),
 
 	// 알림 관련 - C5***
 	NOTIFICATION_NOT_FOUND_EXCEPTION("C5000", "해당 알림을 찾을 수 없습니다.", NotificationNotFoundException.class),


### PR DESCRIPTION
## 기능 명세
- [x] 쓰레기통 리뷰 완료 여부 확인 기능 추가
- [x] 쓰레기통 리뷰를 중복으로 작성할 수 없도록 예외를 추가

### [POST] /api/v2/trashCans/feedbacks
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 1,
        "trashCanId": 21,
        "feedbackCode": 2,
        "feedback": "우수",
        "memberId": 1,
        "createdAt": "2024-08-02T00:06:23.297318"
    }
}
```

### [GET] /api/v2/trashCans/feedbacks/{trashCanId}

리뷰가 아직 작성되지 않은 경우
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": null,
        "trashCanId": 30,
        "feedbackCode": 3,
        "feedback": null,
        "memberId": 1,
        "createdAt": null
    }
}
```
## 함께 의논할 점
> 없으면 생략 
## Resolve
#81