### PR TITLE
feat : 쓰레기통 피드백 업데이트 기능 추가

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/trashCan/domain/BinFeedback.java
+++ b/src/main/java/efub/back/jupjup/domain/trashCan/domain/BinFeedback.java
@@ -47,4 +47,8 @@ public class BinFeedback extends BaseTimeEntity {
 		this.trashCanId = trashCanId;
 		this.member = member;
 	}
+
+	public void updateFeedback(Feedback feedback) {
+		this.feedback = feedback;
+	}
 }


### PR DESCRIPTION
## 기능 명세
- [x] 쓰레기통 피드백 작성/수정 기능
## 결과 
### [POST] /api/v2/trashCans/feedbacks
- 쓰레기통 피드백 작성/수정 기능
- 리뷰를 완료한 쓰레기통에 대해 동일한 feedbackCode로 다시 POST할 경우 예외 발생. 동일하지 않다면 피드백 수정 가능
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 4,
        "trashCanId": 30,
        "feedbackCode": 2,
        "feedback": "우수",
        "memberId": 2,
        "createdAt": "2024-08-16T22:35:53"
    }
}
```

## 함께 의논할 점
> 없으면 생략 
## Resolve
#81 
