### PR TITLE
feat : 프로필 통계 기능 추가

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/back/jupjup/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import efub.back.jupjup.domain.member.domain.Member;
 import efub.back.jupjup.domain.member.dto.request.MemberReqDto;
 import efub.back.jupjup.domain.member.dto.request.NicknameCheckReqDto;
+import efub.back.jupjup.domain.member.service.MemberProfileFacade;
 import efub.back.jupjup.domain.member.service.MemberService;
 import efub.back.jupjup.domain.security.userInfo.AuthUser;
 import efub.back.jupjup.global.response.StatusResponse;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 	private final MemberService memberService;
+	private final MemberProfileFacade memberProfileFacade;
 
 	@GetMapping("/{memberId}")
 	public ResponseEntity<StatusResponse> readProfile(@PathVariable Long memberId) {
@@ -46,4 +48,10 @@ public class MemberController {
 		@AuthUser Member member) {
 		return memberService.checkDuplicateNickname(nicknameCheckReqDto, member);
 	}
+
+	@GetMapping("/stats/{memberId}")
+	public ResponseEntity<StatusResponse> getUserProfileStats(@PathVariable Long memberId) {
+		return memberProfileFacade.getUserProfileStats(memberId);
+	}
+
 }

--- a/src/main/java/efub/back/jupjup/domain/member/dto/response/ProfileStatResDto.java
+++ b/src/main/java/efub/back/jupjup/domain/member/dto/response/ProfileStatResDto.java
@@ -1,0 +1,14 @@
+package efub.back.jupjup.domain.member.dto.response;
+
+import java.math.BigDecimal;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileStatResDto {
+	private int userHeartsCount;
+	private BigDecimal averageScore; // 평균 평점
+	private int postCount;
+}

--- a/src/main/java/efub/back/jupjup/domain/member/service/MemberProfileFacade.java
+++ b/src/main/java/efub/back/jupjup/domain/member/service/MemberProfileFacade.java
@@ -1,0 +1,57 @@
+package efub.back.jupjup.domain.member.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import efub.back.jupjup.domain.member.domain.Member;
+import efub.back.jupjup.domain.member.dto.response.ProfileStatResDto;
+import efub.back.jupjup.domain.member.exception.MemberNotFoundException;
+import efub.back.jupjup.domain.member.repository.MemberRepository;
+import efub.back.jupjup.domain.post.repository.PostRepository;
+import efub.back.jupjup.domain.postjoin.repository.PostjoinRepository;
+import efub.back.jupjup.domain.score.domain.AverageScore;
+import efub.back.jupjup.domain.score.repository.AverageScoreRepository;
+import efub.back.jupjup.domain.userHeart.repository.UserHeartRepository;
+import efub.back.jupjup.global.response.StatusEnum;
+import efub.back.jupjup.global.response.StatusResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class MemberProfileFacade {
+	private final MemberRepository memberRepository;
+	private final PostRepository postRepository;
+	private final PostjoinRepository postjoinRepository;
+	private final UserHeartRepository userHeartRepository;
+	private final AverageScoreRepository averageScoreRepository;
+
+	@Transactional(readOnly = true)
+	public ResponseEntity<StatusResponse> getUserProfileStats(Long memberId) {
+		Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+		// 주최한 플로깅 개수
+		int hostCount = (int)postRepository.countByAuthor(member);
+		int joinCount = (int)postjoinRepository.countByMember(member);
+		int postCount = hostCount + joinCount;
+		int userHeartCount = userHeartRepository.countUserHeartsByMemberId(memberId).intValue();
+		BigDecimal averageScore = averageScoreRepository.findById(memberId)
+			.map(AverageScore::getAverageScore)
+			.orElse(BigDecimal.ZERO);
+
+		ProfileStatResDto profileStatResDto = ProfileStatResDto.builder()
+			.averageScore(averageScore)
+			.postCount(postCount)
+			.userHeartsCount(userHeartCount)
+			.build();
+
+		return ResponseEntity.ok()
+			.body(StatusResponse.builder()
+				.status(StatusEnum.OK.getStatusCode())
+				.message(StatusEnum.OK.getCode())
+				.data(profileStatResDto)
+				.build());
+	}
+
+}


### PR DESCRIPTION
## 기능 명세
- [x] 유저 통계 기능

## 결과 
### [GET] /api/v1/members/stats/{memberId}
- userHeart(좋아요 수), postCount(플로깅 횟수), averageScore(플로깅 평점)를 포함하는 통계값 제공
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "userHeartsCount": 1,
        "averageScore": 4.0,
        "postCount": 2
    }
}
```

## 함께 의논할 점
> 없으면 생략 
## Resolve
#79 
