### PR TITLE
refactor: joinedMemberCount 작성자 포함되도록 수정

### DIFF
--- a/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
+++ b/src/main/java/efub/back/jupjup/domain/post/service/PostService.java
@@ -68,7 +68,7 @@ public class PostService {
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = now.isAfter(post.getDueDate());
 			boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-			Long joinedMemberCount = postjoinRepository.countByPost(post);
+			Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 		}).collect(Collectors.toList());
@@ -86,7 +86,7 @@ public class PostService {
 		boolean isHearted = false;
 		boolean isAuthor = true;
 		boolean isReviewed = false;
-		Long joinedMemberCount = postjoinRepository.countByPost(post);
+		Long joinedMemberCount = 1L;
 
 		PostResponseDto postResponseDto = PostResponseDto.of(post, imageUrls, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 
@@ -110,7 +110,7 @@ public class PostService {
 		boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 		boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 		boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-		Long joinedMemberCount = postjoinRepository.countByPost(post);
+		Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 
 		PostResponseDto responseDto = PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
@@ -134,7 +134,7 @@ public class PostService {
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 			boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-			Long joinedMemberCount = postjoinRepository.countByPost(post);
+			Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 		}).collect(Collectors.toList());
@@ -161,7 +161,7 @@ public class PostService {
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 			boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-			Long joinedMemberCount = postjoinRepository.countByPost(post);
+			Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 		}).collect(Collectors.toList());
@@ -187,7 +187,7 @@ public class PostService {
 			boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 			boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 			boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-			Long joinedMemberCount = postjoinRepository.countByPost(post);
+			Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 			return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 		}).collect(Collectors.toList());
@@ -258,7 +258,7 @@ public class PostService {
 				boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 				boolean isEnded = LocalDateTime.now().isAfter(post.getDueDate());
 				boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-				Long joinedMemberCount = postjoinRepository.countByPost(post);
+				Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 				return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 			}).collect(Collectors.toList());
@@ -287,7 +287,7 @@ public class PostService {
 			boolean isEnded = now.isAfter(post.getStartDate());
 			boolean isAuthor = post.getAuthor().getId().equals(member.getId());
 			boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-			Long joinedMemberCount = postjoinRepository.countByPost(post);
+			Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 			PostResponseDto dto = PostResponseDto.of(post, urlList, Optional.of(true),
 				Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
@@ -375,7 +375,7 @@ public class PostService {
 		boolean isHearted = heartRepository.existsByMemberAndPost(member, post);
 		boolean isEnded = now.isAfter(post.getDueDate());
 		boolean isReviewed = scoreRepository.existsByParticipantAndPost(member, post);
-		Long joinedMemberCount = postjoinRepository.countByPost(post);
+		Long joinedMemberCount = postjoinRepository.countByPost(post) + 1;
 
 		return PostResponseDto.of(post, urlList, Optional.of(isJoined), Optional.of(isHearted), isEnded, isAuthor, isReviewed, joinedMemberCount);
 	}


### PR DESCRIPTION
## 기능 명세
- [x] joinedMemberCount에서 작성자 포함되도록 수정

## 결과 
🔻예시
### [GET] /api/v1/members
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "id": 2,
        "title": "플로깅해요~",
        "startDate": "2024-08-19T09:30:00",
        "dueDate": "2024-08-10T11:30:00",
        "minAge": 25,
        "maxAge": 30,
        "minMember": 2,
        "maxMember": 10,
        "postGender": "FEMALE",
        "withPet": true,
        "content": "2번째 게시글 입니다. ",
        "createdAt": "2024-08-19T00:04:40.7365743",
        "fileUrls": [
            "https://",
            "https://"
        ],
        "route": [
            {
                "address": "string",
                "latitude": 87.123456,
                "longitude": 31.123456
            },
            {
                "address": "string",
                "latitude": 17.234567,
                "longitude": 17.234567
            },
            {
                "address": "string",
                "latitude": 17.234567,
                "longitude": 17.234567
            }
        ],
        "district": "SEODAEMUN",
        "authorId": 1,
        "isJoined": true,
        "isHearted": false,
        "isEnded": false,
        "isAuthor": true,
        "authorNickname": "채원",
        "authorProfileImageUrl": null,
        "isRecruitmentSuccessful": false,
        "isReviewed": false,
        "joinedMemberCount": 1
    }
}
```

## 함께 의논할 점
> 없으면 생략 

## Resolve
> #77 
